### PR TITLE
refactor: extract shared JSON helpers into json_mini.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,8 @@ else()
         HINTS ${BORINGSSL_BUILD_DIR} ${BORINGSSL_BUILD_DIR}/crypto /usr/local/lib /usr/local/babassl/lib)
 endif()
 
-# ---------- libmqvpn (static library — no libevent, no platform I/O) ----------
-add_library(mqvpn_lib STATIC
+# ---------- libmqvpn source files (shared between static and shared targets) ----------
+set(MQVPN_LIB_SOURCES
     src/mqvpn_config.c
     src/mqvpn_client.c
     src/mqvpn_server.c
@@ -105,6 +105,9 @@ add_library(mqvpn_lib STATIC
     src/auth.c
     src/log.c
 )
+
+# ---------- libmqvpn (static library — no libevent, no platform I/O) ----------
+add_library(mqvpn_lib STATIC ${MQVPN_LIB_SOURCES})
 if(WIN32)
     set_target_properties(mqvpn_lib PROPERTIES OUTPUT_NAME mqvpn_lib)
 else()
@@ -177,16 +180,7 @@ endif()
 else() # NOT WIN32 — Linux
 
 # Shared library variant
-add_library(mqvpn_shared SHARED
-    src/mqvpn_config.c
-    src/mqvpn_client.c
-    src/mqvpn_server.c
-    src/mqvpn_util.c
-    src/flow_sched.c
-    src/addr_pool.c
-    src/auth.c
-    src/log.c
-)
+add_library(mqvpn_shared SHARED ${MQVPN_LIB_SOURCES})
 set_target_properties(mqvpn_shared PROPERTIES
     OUTPUT_NAME mqvpn
     SOVERSION 0

--- a/src/config.c
+++ b/src/config.c
@@ -2,6 +2,7 @@
  * config.c — INI/JSON configuration file parser for mqvpn
  */
 #include "config.h"
+#include "json_mini.h"
 #include "log.h"
 
 #include <stdio.h>
@@ -28,17 +29,7 @@ trim(char *s)
     return s;
 }
 
-static void
-copy_str(char *dst, size_t dst_len, const char *src)
-{
-    if (!dst || dst_len == 0) return;
-    if (!src) {
-        dst[0] = '\0';
-        return;
-    }
-    strncpy(dst, src, dst_len - 1);
-    dst[dst_len - 1] = '\0';
-}
+/* mqvpn_copy_str is provided by json_mini.h as mqvpn_copy_str */
 
 /* Parse boolean: "true"/"yes"/"1" → 1, else 0 */
 static int
@@ -154,76 +145,8 @@ parse_user_pair(mqvpn_config_t *cfg, const char *val, int lineno, const char *pa
     add_user_entry(cfg, name, key, lineno, path);
 }
 
-static const char *json_skip_ws(const char *p)
-{
-    while (*p && isspace((unsigned char)*p)) p++;
-    return p;
-}
-
-static const char *json_find_key(const char *json, const char *key)
-{
-    size_t key_len = strlen(key);
-    const char *p = json;
-
-    while ((p = strchr(p, '"')) != NULL) {
-        const char *k = p + 1;
-        const char *e = k;
-        while (*e && *e != '"') {
-            if (*e == '\\' && e[1]) e++;
-            e++;
-        }
-        if (*e != '"') return NULL;
-
-        if ((size_t)(e - k) == key_len && strncmp(k, key, key_len) == 0) {
-            const char *c = json_skip_ws(e + 1);
-            if (*c == ':') {
-                return json_skip_ws(c + 1);
-            }
-        }
-        p = e + 1;
-    }
-    return NULL;
-}
-
-static int json_read_string(const char *p, char *out, size_t out_len)
-{
-    if (!p || !out || out_len == 0 || *p != '"') return -1;
-    p++;
-
-    size_t j = 0;
-    while (*p && *p != '"') {
-        if (*p == '\\' && p[1]) p++;
-        if (j + 1 < out_len) out[j++] = *p;
-        p++;
-    }
-    if (*p != '"') return -1;
-    out[j] = '\0';
-    return 0;
-}
-
-static int json_read_bool(const char *p, int *out)
-{
-    if (!p || !out) return -1;
-    if (strncmp(p, "true", 4) == 0) {
-        *out = 1;
-        return 0;
-    }
-    if (strncmp(p, "false", 5) == 0) {
-        *out = 0;
-        return 0;
-    }
-    return -1;
-}
-
-static int json_read_int(const char *p, int *out)
-{
-    if (!p || !out) return -1;
-    char *end = NULL;
-    long v = strtol(p, &end, 10);
-    if (end == p) return -1;
-    *out = (int)v;
-    return 0;
-}
+/* json_skip_ws, json_find_key, json_read_string, json_read_bool,
+ * json_read_int are provided by json_mini.h */
 
 static int json_read_string_array(const char *p,
                                   char out[][64],
@@ -272,8 +195,8 @@ static int json_read_users(mqvpn_config_t *cfg, const char *p)
             char *sep = strchr(pair, ':');
             if (!sep) return -1;
             *sep = '\0';
-            copy_str(name, sizeof(name), pair);
-            copy_str(key, sizeof(key), sep + 1);
+            mqvpn_copy_str(name, sizeof(name), pair);
+            mqvpn_copy_str(key, sizeof(key), sep + 1);
 
             const char *e = p + 1;
             while (*e && *e != '"') {
@@ -420,55 +343,55 @@ mqvpn_config_load_json_filecfg(mqvpn_config_t *cfg, const char *json_text)
 
     v = json_find_key(json_text, "tun_name");
     if (v && json_read_string(v, s32, sizeof(s32)) == 0)
-        copy_str(cfg->tun_name, sizeof(cfg->tun_name), s32);
+        mqvpn_copy_str(cfg->tun_name, sizeof(cfg->tun_name), s32);
 
     v = json_find_key(json_text, "log_level");
     if (v && json_read_string(v, s32, sizeof(s32)) == 0)
-        copy_str(cfg->log_level, sizeof(cfg->log_level), s32);
+        mqvpn_copy_str(cfg->log_level, sizeof(cfg->log_level), s32);
 
     v = json_find_key(json_text, "listen");
     if (v && json_read_string(v, s280, sizeof(s280)) == 0) {
-        copy_str(cfg->listen, sizeof(cfg->listen), s280);
+        mqvpn_copy_str(cfg->listen, sizeof(cfg->listen), s280);
         cfg->is_server = 1;
     }
 
     v = json_find_key(json_text, "subnet");
     if (v && json_read_string(v, s64, sizeof(s64)) == 0)
-        copy_str(cfg->subnet, sizeof(cfg->subnet), s64);
+        mqvpn_copy_str(cfg->subnet, sizeof(cfg->subnet), s64);
 
     v = json_find_key(json_text, "subnet6");
     if (v && json_read_string(v, s64, sizeof(s64)) == 0)
-        copy_str(cfg->subnet6, sizeof(cfg->subnet6), s64);
+        mqvpn_copy_str(cfg->subnet6, sizeof(cfg->subnet6), s64);
 
     v = json_find_key(json_text, "server_addr");
     if (v && json_read_string(v, s280, sizeof(s280)) == 0)
-        copy_str(cfg->server_addr, sizeof(cfg->server_addr), s280);
+        mqvpn_copy_str(cfg->server_addr, sizeof(cfg->server_addr), s280);
 
     v = json_find_key(json_text, "insecure");
     if (v && json_read_bool(v, &iv) == 0) cfg->insecure = iv;
 
     v = json_find_key(json_text, "auth_key");
     if (v && json_read_string(v, s256, sizeof(s256)) == 0)
-        copy_str(cfg->auth_key, sizeof(cfg->auth_key), s256);
+        mqvpn_copy_str(cfg->auth_key, sizeof(cfg->auth_key), s256);
 
     v = json_find_key(json_text, "server_auth_key");
     if (v && json_read_string(v, s256, sizeof(s256)) == 0)
-        copy_str(cfg->server_auth_key, sizeof(cfg->server_auth_key), s256);
+        mqvpn_copy_str(cfg->server_auth_key, sizeof(cfg->server_auth_key), s256);
 
     v = json_find_key(json_text, "cert_file");
     if (v && json_read_string(v, s256, sizeof(s256)) == 0)
-        copy_str(cfg->cert_file, sizeof(cfg->cert_file), s256);
+        mqvpn_copy_str(cfg->cert_file, sizeof(cfg->cert_file), s256);
 
     v = json_find_key(json_text, "key_file");
     if (v && json_read_string(v, s256, sizeof(s256)) == 0)
-        copy_str(cfg->key_file, sizeof(cfg->key_file), s256);
+        mqvpn_copy_str(cfg->key_file, sizeof(cfg->key_file), s256);
 
     v = json_find_key(json_text, "max_clients");
     if (v && json_read_int(v, &iv) == 0) cfg->max_clients = iv > 0 ? iv : 64;
 
     v = json_find_key(json_text, "scheduler");
     if (v && json_read_string(v, s32, sizeof(s32)) == 0)
-        copy_str(cfg->scheduler, sizeof(cfg->scheduler), s32);
+        mqvpn_copy_str(cfg->scheduler, sizeof(cfg->scheduler), s32);
 
     v = json_find_key(json_text, "reconnect");
     if (v && json_read_bool(v, &iv) == 0) cfg->reconnect = iv;
@@ -485,7 +408,7 @@ mqvpn_config_load_json_filecfg(mqvpn_config_t *cfg, const char *json_text)
     if (v && json_read_string_array(v, dns_buf, MQVPN_CONFIG_MAX_DNS, &n_dns) == 0) {
         cfg->n_dns = 0;
         for (int i = 0; i < n_dns; i++) {
-            copy_str(cfg->dns_servers[cfg->n_dns], sizeof(cfg->dns_servers[cfg->n_dns]),
+            mqvpn_copy_str(cfg->dns_servers[cfg->n_dns], sizeof(cfg->dns_servers[cfg->n_dns]),
                      dns_buf[i]);
             cfg->n_dns++;
         }
@@ -497,7 +420,7 @@ mqvpn_config_load_json_filecfg(mqvpn_config_t *cfg, const char *json_text)
     if (v && json_read_string_array(v, path_buf, MQVPN_CONFIG_MAX_PATHS, &n_paths) == 0) {
         cfg->n_paths = 0;
         for (int i = 0; i < n_paths; i++) {
-            copy_str(cfg->paths[cfg->n_paths], sizeof(cfg->paths[cfg->n_paths]),
+            mqvpn_copy_str(cfg->paths[cfg->n_paths], sizeof(cfg->paths[cfg->n_paths]),
                      path_buf[i]);
             cfg->n_paths++;
         }

--- a/src/json_mini.h
+++ b/src/json_mini.h
@@ -1,0 +1,106 @@
+/*
+ * json_mini.h — Minimal JSON parsing helpers (static inline)
+ *
+ * Shared across config.c, mqvpn_config.c, control_socket.c, status.c.
+ * No dependencies beyond libc.
+ */
+#ifndef MQVPN_JSON_MINI_H
+#define MQVPN_JSON_MINI_H
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <ctype.h>
+
+static inline const char *
+json_skip_ws(const char *p)
+{
+    while (*p && isspace((unsigned char)*p)) p++;
+    return p;
+}
+
+/* Find a key in a JSON object. Returns pointer to the value, or NULL. */
+static inline const char *
+json_find_key(const char *json, const char *key)
+{
+    size_t key_len = strlen(key);
+    const char *p = json;
+
+    while ((p = strchr(p, '"')) != NULL) {
+        const char *k = p + 1;
+        const char *e = k;
+        while (*e && *e != '"') {
+            if (*e == '\\' && e[1]) e++;
+            e++;
+        }
+        if (*e != '"') return NULL;
+
+        if ((size_t)(e - k) == key_len && strncmp(k, key, key_len) == 0) {
+            const char *c = json_skip_ws(e + 1);
+            if (*c == ':') {
+                return json_skip_ws(c + 1);
+            }
+        }
+        p = e + 1;
+    }
+    return NULL;
+}
+
+/* Read a JSON string value. Returns 0 on success, -1 on error. */
+static inline int
+json_read_string(const char *p, char *out, size_t out_len)
+{
+    if (!p || !out || out_len == 0 || *p != '"') return -1;
+    p++;
+    size_t j = 0;
+    while (*p && *p != '"') {
+        if (*p == '\\' && p[1]) p++;
+        if (j + 1 < out_len) out[j++] = *p;
+        p++;
+    }
+    if (*p != '"') return -1;
+    out[j] = '\0';
+    return 0;
+}
+
+/* Read a JSON boolean value. Returns 0 on success, -1 on error. */
+static inline int
+json_read_bool(const char *p, int *out)
+{
+    if (!p || !out) return -1;
+    if (strncmp(p, "true", 4) == 0)  { *out = 1; return 0; }
+    if (strncmp(p, "false", 5) == 0) { *out = 0; return 0; }
+    return -1;
+}
+
+/* Read a JSON integer value (int). Returns 0 on success, -1 on error. */
+static inline int
+json_read_int(const char *p, int *out)
+{
+    if (!p || !out) return -1;
+    char *end = NULL;
+    long v = strtol(p, &end, 10);
+    if (end == p) return -1;
+    *out = (int)v;
+    return 0;
+}
+
+/* Read a JSON integer value (int64_t). Returns 0 or the value itself. */
+static inline int64_t
+json_read_int64(const char *p)
+{
+    if (!p) return 0;
+    return strtoll(p, NULL, 10);
+}
+
+/* Safe string copy with NUL termination. */
+static inline void
+mqvpn_copy_str(char *dst, size_t dst_len, const char *src)
+{
+    if (!dst || dst_len == 0) return;
+    if (!src) { dst[0] = '\0'; return; }
+    strncpy(dst, src, dst_len - 1);
+    dst[dst_len - 1] = '\0';
+}
+
+#endif /* MQVPN_JSON_MINI_H */

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include "log.h"
 #include "config.h"
+#include "json_mini.h"
 #include "auth.h"
 #include "vpn_client.h"
 #include "vpn_server.h"
@@ -95,17 +96,7 @@ parse_host_port(const char *str, char *host, size_t host_len, int *port)
     return 0;
 }
 
-static void
-copy_str(char *dst, size_t dst_len, const char *src)
-{
-    if (!dst || dst_len == 0) return;
-    if (!src) {
-        dst[0] = '\0';
-        return;
-    }
-    strncpy(dst, src, dst_len - 1);
-    dst[dst_len - 1] = '\0';
-}
+/* mqvpn_copy_str is provided by json_mini.h as mqvpn_copy_str */
 
 int
 main(int argc, char *argv[])
@@ -202,8 +193,8 @@ main(int argc, char *argv[])
                 return 1;
             }
             *sep = '\0';
-            copy_str(cli_user_names[n_cli_users], sizeof(cli_user_names[n_cli_users]), pair);
-            copy_str(cli_user_keys[n_cli_users], sizeof(cli_user_keys[n_cli_users]), sep + 1);
+            mqvpn_copy_str(cli_user_names[n_cli_users], sizeof(cli_user_names[n_cli_users]), pair);
+            mqvpn_copy_str(cli_user_keys[n_cli_users], sizeof(cli_user_keys[n_cli_users]), sep + 1);
             if (cli_user_names[n_cli_users][0] == '\0' || cli_user_keys[n_cli_users][0] == '\0') {
                 fprintf(stderr, "error: --user must be NAME:KEY\n");
                 return 1;

--- a/src/mqvpn_config.c
+++ b/src/mqvpn_config.c
@@ -6,109 +6,30 @@
 
 #include "libmqvpn.h"
 #include "mqvpn_internal.h"
+#include "json_mini.h"
 
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <ctype.h>
 
 int mqvpn_config_add_user(mqvpn_config_t *cfg,
                           const char *username,
                           const char *key);
 
-static const char *skip_ws(const char *p)
-{
-    while (*p && isspace((unsigned char)*p)) p++;
-    return p;
-}
-
-static void copy_str(char *dst, size_t dst_len, const char *src)
-{
-    if (!dst || dst_len == 0) return;
-    if (!src) {
-        dst[0] = '\0';
-        return;
-    }
-    strncpy(dst, src, dst_len - 1);
-    dst[dst_len - 1] = '\0';
-}
-
-static const char *json_find_key(const char *json, const char *key)
-{
-    size_t key_len = strlen(key);
-    const char *p = json;
-
-    while ((p = strchr(p, '"')) != NULL) {
-        const char *k = p + 1;
-        const char *e = k;
-        while (*e && *e != '"') {
-            if (*e == '\\' && e[1]) e++;
-            e++;
-        }
-        if (*e != '"') return NULL;
-
-        if ((size_t)(e - k) == key_len && strncmp(k, key, key_len) == 0) {
-            const char *c = skip_ws(e + 1);
-            if (*c == ':') {
-                return skip_ws(c + 1);
-            }
-        }
-        p = e + 1;
-    }
-    return NULL;
-}
-
-static int json_read_string(const char *p, char *out, size_t out_len)
-{
-    if (!p || *p != '"' || !out || out_len == 0) return MQVPN_ERR_INVALID_ARG;
-    p++;
-
-    size_t j = 0;
-    while (*p && *p != '"') {
-        if (*p == '\\' && p[1]) p++;
-        if (j + 1 < out_len) out[j++] = *p;
-        p++;
-    }
-    if (*p != '"') return MQVPN_ERR_INVALID_ARG;
-    out[j] = '\0';
-    return MQVPN_OK;
-}
-
-static int json_read_bool(const char *p, int *out)
-{
-    if (!p || !out) return MQVPN_ERR_INVALID_ARG;
-    if (strncmp(p, "true", 4) == 0) {
-        *out = 1;
-        return MQVPN_OK;
-    }
-    if (strncmp(p, "false", 5) == 0) {
-        *out = 0;
-        return MQVPN_OK;
-    }
-    return MQVPN_ERR_INVALID_ARG;
-}
-
-static int json_read_int(const char *p, int *out)
-{
-    if (!p || !out) return MQVPN_ERR_INVALID_ARG;
-    char *end = NULL;
-    long v = strtol(p, &end, 10);
-    if (end == p) return MQVPN_ERR_INVALID_ARG;
-    *out = (int)v;
-    return MQVPN_OK;
-}
+/* json_skip_ws, mqvpn_copy_str, json_find_key, json_read_string, json_read_bool,
+ * json_read_int are provided by json_mini.h */
 
 static int json_read_string_array(const char *p,
                                   char out[][32], int max_items, int *n_items)
 {
     if (!p || !out || !n_items || *p != '[') return MQVPN_ERR_INVALID_ARG;
-    p = skip_ws(p + 1);
+    p = json_skip_ws(p + 1);
 
     int n = 0;
     while (*p && *p != ']') {
         if (*p != '"') return MQVPN_ERR_INVALID_ARG;
         if (n >= max_items) return MQVPN_ERR_INVALID_ARG;
-        if (json_read_string(p, out[n], sizeof(out[n])) != MQVPN_OK) {
+        if (json_read_string(p, out[n], sizeof(out[n])) != 0) {
             return MQVPN_ERR_INVALID_ARG;
         }
 
@@ -118,11 +39,11 @@ static int json_read_string_array(const char *p,
             e++;
         }
         if (*e != '"') return MQVPN_ERR_INVALID_ARG;
-        p = skip_ws(e + 1);
+        p = json_skip_ws(e + 1);
         n++;
 
         if (*p == ',') {
-            p = skip_ws(p + 1);
+            p = json_skip_ws(p + 1);
         } else if (*p != ']') {
             return MQVPN_ERR_INVALID_ARG;
         }
@@ -136,7 +57,7 @@ static int json_read_string_array(const char *p,
 static int json_read_users(mqvpn_config_t *cfg, const char *p)
 {
     if (!cfg || !p || *p != '[') return MQVPN_ERR_INVALID_ARG;
-    p = skip_ws(p + 1);
+    p = json_skip_ws(p + 1);
     cfg->n_users = 0;
 
     while (*p && *p != ']') {
@@ -151,8 +72,8 @@ static int json_read_users(mqvpn_config_t *cfg, const char *p)
             char *sep = strchr(pair, ':');
             if (!sep) return MQVPN_ERR_INVALID_ARG;
             *sep = '\0';
-            copy_str(uname, sizeof(uname), pair);
-            copy_str(key, sizeof(key), sep + 1);
+            mqvpn_copy_str(uname, sizeof(uname), pair);
+            mqvpn_copy_str(key, sizeof(key), sep + 1);
 
             const char *e = p + 1;
             while (*e && *e != '"') {
@@ -160,7 +81,7 @@ static int json_read_users(mqvpn_config_t *cfg, const char *p)
                 e++;
             }
             if (*e != '"') return MQVPN_ERR_INVALID_ARG;
-            p = skip_ws(e + 1);
+            p = json_skip_ws(e + 1);
         } else if (*p == '{') {
             const char *obj_end = strchr(p, '}');
             if (!obj_end) return MQVPN_ERR_INVALID_ARG;
@@ -181,7 +102,7 @@ static int json_read_users(mqvpn_config_t *cfg, const char *p)
                 return MQVPN_ERR_INVALID_ARG;
             }
 
-            p = skip_ws(obj_end + 1);
+            p = json_skip_ws(obj_end + 1);
         } else {
             return MQVPN_ERR_INVALID_ARG;
         }
@@ -191,7 +112,7 @@ static int json_read_users(mqvpn_config_t *cfg, const char *p)
         }
 
         if (*p == ',') {
-            p = skip_ws(p + 1);
+            p = json_skip_ws(p + 1);
         } else if (*p != ']') {
             return MQVPN_ERR_INVALID_ARG;
         }
@@ -314,7 +235,7 @@ int mqvpn_config_load_json(mqvpn_config_t *cfg, const char *json_text)
 
     v = json_find_key(json_text, "server_host");
     if (v && json_read_string(v, tmp, sizeof(tmp)) == MQVPN_OK) {
-        copy_str(cfg->server_host, sizeof(cfg->server_host), tmp);
+        mqvpn_copy_str(cfg->server_host, sizeof(cfg->server_host), tmp);
     }
 
     v = json_find_key(json_text, "server_port");
@@ -324,12 +245,12 @@ int mqvpn_config_load_json(mqvpn_config_t *cfg, const char *json_text)
 
     v = json_find_key(json_text, "auth_key");
     if (v && json_read_string(v, tmp, sizeof(tmp)) == MQVPN_OK) {
-        copy_str(cfg->auth_key, sizeof(cfg->auth_key), tmp);
+        mqvpn_copy_str(cfg->auth_key, sizeof(cfg->auth_key), tmp);
     }
 
     v = json_find_key(json_text, "listen_addr");
     if (v && json_read_string(v, tmp, sizeof(tmp)) == MQVPN_OK) {
-        copy_str(cfg->listen_addr, sizeof(cfg->listen_addr), tmp);
+        mqvpn_copy_str(cfg->listen_addr, sizeof(cfg->listen_addr), tmp);
     }
 
     v = json_find_key(json_text, "listen_port");
@@ -339,22 +260,22 @@ int mqvpn_config_load_json(mqvpn_config_t *cfg, const char *json_text)
 
     v = json_find_key(json_text, "subnet");
     if (v && json_read_string(v, tmp, sizeof(tmp)) == MQVPN_OK) {
-        copy_str(cfg->subnet, sizeof(cfg->subnet), tmp);
+        mqvpn_copy_str(cfg->subnet, sizeof(cfg->subnet), tmp);
     }
 
     v = json_find_key(json_text, "subnet6");
     if (v && json_read_string(v, tmp, sizeof(tmp)) == MQVPN_OK) {
-        copy_str(cfg->subnet6, sizeof(cfg->subnet6), tmp);
+        mqvpn_copy_str(cfg->subnet6, sizeof(cfg->subnet6), tmp);
     }
 
     v = json_find_key(json_text, "tls_cert");
     if (v && json_read_string(v, tmp, sizeof(tmp)) == MQVPN_OK) {
-        copy_str(cfg->tls_cert, sizeof(cfg->tls_cert), tmp);
+        mqvpn_copy_str(cfg->tls_cert, sizeof(cfg->tls_cert), tmp);
     }
 
     v = json_find_key(json_text, "tls_key");
     if (v && json_read_string(v, tmp, sizeof(tmp)) == MQVPN_OK) {
-        copy_str(cfg->tls_key, sizeof(cfg->tls_key), tmp);
+        mqvpn_copy_str(cfg->tls_key, sizeof(cfg->tls_key), tmp);
     }
 
     v = json_find_key(json_text, "max_clients");

--- a/src/platform/linux/control_socket.c
+++ b/src/platform/linux/control_socket.c
@@ -17,6 +17,7 @@
  */
 
 #include "control_socket.h"
+#include "json_mini.h"
 #include "log.h"
 
 #include <stdlib.h>
@@ -37,46 +38,8 @@
 #define CTRL_MAX_CONNS 8         /* max concurrent control connections */
 #define CTRL_READ_TIMEOUT_SEC 5  /* close idle connections after 5s */
 
-/* ── Minimal JSON helpers (same fixed escape logic as config.c) ─────────── */
-
-static const char *
-jfind(const char *json, const char *key)
-{
-    size_t klen = strlen(key);
-    const char *p = json;
-    while ((p = strchr(p, '"')) != NULL) {
-        const char *k = p + 1, *e = k;
-        while (*e && *e != '"') { if (*e == '\\' && e[1]) e++; e++; }
-        if (*e != '"') return NULL;
-        if ((size_t)(e - k) == klen && strncmp(k, key, klen) == 0) {
-            const char *c = e + 1;
-            while (*c && isspace((unsigned char)*c)) c++;
-            if (*c == ':') {
-                c++;
-                while (*c && isspace((unsigned char)*c)) c++;
-                return c;
-            }
-        }
-        p = e + 1;
-    }
-    return NULL;
-}
-
-static int
-jstr(const char *p, char *out, size_t out_len)
-{
-    if (!p || *p != '"' || !out || out_len == 0) return -1;
-    p++;
-    size_t j = 0;
-    while (*p && *p != '"') {
-        if (*p == '\\' && p[1]) p++;
-        if (j + 1 < out_len) out[j++] = *p;
-        p++;
-    }
-    if (*p != '"') return -1;
-    out[j] = '\0';
-    return 0;
-}
+/* JSON helpers (json_find_key → json_find_key, json_read_string → json_read_string)
+ * are provided by json_mini.h */
 
 /* ── Per-connection state ────────────────────────────────────────────────── */
 
@@ -104,16 +67,16 @@ static int
 dispatch(const char *req, char *resp, size_t resp_len, mqvpn_server_t *server)
 {
     char cmd[32] = {0};
-    const char *v = jfind(req, "cmd");
-    if (!v || jstr(v, cmd, sizeof(cmd)) < 0)
+    const char *v = json_find_key(req, "cmd");
+    if (!v || json_read_string(v, cmd, sizeof(cmd)) < 0)
         return snprintf(resp, resp_len, "{\"ok\":false,\"error\":\"missing cmd\"}");
 
     if (strcmp(cmd, "add_user") == 0) {
         char name[64] = {0}, key[256] = {0};
-        const char *nv = jfind(req, "name");
-        const char *kv = jfind(req, "key");
-        if (!nv || jstr(nv, name, sizeof(name)) < 0 ||
-            !kv || jstr(kv, key,  sizeof(key))  < 0)
+        const char *nv = json_find_key(req, "name");
+        const char *kv = json_find_key(req, "key");
+        if (!nv || json_read_string(nv, name, sizeof(name)) < 0 ||
+            !kv || json_read_string(kv, key,  sizeof(key))  < 0)
             return snprintf(resp, resp_len,
                             "{\"ok\":false,\"error\":\"name and key required\"}");
 
@@ -125,8 +88,8 @@ dispatch(const char *req, char *resp, size_t resp_len, mqvpn_server_t *server)
 
     } else if (strcmp(cmd, "remove_user") == 0) {
         char name[64] = {0};
-        const char *nv = jfind(req, "name");
-        if (!nv || jstr(nv, name, sizeof(name)) < 0)
+        const char *nv = json_find_key(req, "name");
+        if (!nv || json_read_string(nv, name, sizeof(name)) < 0)
             return snprintf(resp, resp_len,
                             "{\"ok\":false,\"error\":\"name required\"}");
 

--- a/src/platform/linux/status.c
+++ b/src/platform/linux/status.c
@@ -2,6 +2,7 @@
  * status.c — mqvpn --status: query control API and display server status
  */
 #include "status.h"
+#include "json_mini.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,60 +19,8 @@
 
 #define STATUS_BUF_SIZE 32768
 
-/* ── Minimal JSON helpers ── */
-
-static const char *
-skip_ws(const char *p)
-{
-    while (*p && isspace((unsigned char)*p)) p++;
-    return p;
-}
-
-static const char *
-jfind(const char *json, const char *key)
-{
-    size_t klen = strlen(key);
-    const char *p = json;
-    while ((p = strchr(p, '"')) != NULL) {
-        const char *k = p + 1, *e = k;
-        while (*e && *e != '"') { if (*e == '\\' && e[1]) e++; e++; }
-        if (*e != '"') return NULL;
-        if ((size_t)(e - k) == klen && strncmp(k, key, klen) == 0) {
-            const char *c = e + 1;
-            while (*c && isspace((unsigned char)*c)) c++;
-            if (*c == ':') {
-                c++;
-                while (*c && isspace((unsigned char)*c)) c++;
-                return c;
-            }
-        }
-        p = e + 1;
-    }
-    return NULL;
-}
-
-static int
-jstr(const char *p, char *out, size_t out_len)
-{
-    if (!p || *p != '"' || !out || out_len == 0) return -1;
-    p++;
-    size_t j = 0;
-    while (*p && *p != '"') {
-        if (*p == '\\' && p[1]) p++;
-        if (j + 1 < out_len) out[j++] = *p;
-        p++;
-    }
-    if (*p != '"') return -1;
-    out[j] = '\0';
-    return 0;
-}
-
-static int64_t
-jint(const char *p)
-{
-    if (!p) return 0;
-    return strtoll(p, NULL, 10);
-}
+/* JSON helpers (json_find_key, json_read_string, json_read_int64,
+ * json_skip_ws) are provided by json_mini.h */
 
 /* ── Human-readable formatting ── */
 
@@ -120,7 +69,7 @@ format_size(uint64_t bytes, char *buf, size_t len)
 static const char *
 skip_json_value(const char *p)
 {
-    p = skip_ws(p);
+    p = json_skip_ws(p);
     if (*p == '"') {
         p++;
         while (*p && *p != '"') { if (*p == '\\' && p[1]) p++; p++; }
@@ -158,14 +107,14 @@ print_client(const char *obj)
     char user[64] = {0}, endpoint[64] = {0};
     const char *v;
 
-    v = jfind(obj, "user");
-    if (v) jstr(v, user, sizeof(user));
-    v = jfind(obj, "endpoint");
-    if (v) jstr(v, endpoint, sizeof(endpoint));
+    v = json_find_key(obj, "user");
+    if (v) json_read_string(v, user, sizeof(user));
+    v = json_find_key(obj, "endpoint");
+    if (v) json_read_string(v, endpoint, sizeof(endpoint));
 
-    uint64_t conn_sec = (uint64_t)jint(jfind(obj, "connected_sec"));
-    uint64_t bytes_tx = (uint64_t)jint(jfind(obj, "bytes_tx"));
-    uint64_t bytes_rx = (uint64_t)jint(jfind(obj, "bytes_rx"));
+    uint64_t conn_sec = (uint64_t)json_read_int64(json_find_key(obj, "connected_sec"));
+    uint64_t bytes_tx = (uint64_t)json_read_int64(json_find_key(obj, "bytes_tx"));
+    uint64_t bytes_rx = (uint64_t)json_read_int64(json_find_key(obj, "bytes_rx"));
 
     char dur[32], tx[32], rx[32];
     format_duration(conn_sec, dur, sizeof(dur));
@@ -178,9 +127,9 @@ print_client(const char *obj)
     printf("  transfer: %s received, %s sent\n", rx, tx);
 
     /* Print paths */
-    v = jfind(obj, "paths");
+    v = json_find_key(obj, "paths");
     if (!v || *v != '[') return;
-    const char *p = skip_ws(v + 1);
+    const char *p = json_skip_ws(v + 1);
     int idx = 0;
 
     while (*p && *p != ']') {
@@ -194,10 +143,10 @@ print_client(const char *obj)
             memcpy(path_obj, p, plen);
             path_obj[plen] = '\0';
 
-            int64_t srtt = jint(jfind(path_obj, "srtt_ms"));
-            int64_t min_rtt = jint(jfind(path_obj, "min_rtt_ms"));
-            uint64_t cwnd = (uint64_t)jint(jfind(path_obj, "cwnd"));
-            int state = (int)jint(jfind(path_obj, "state"));
+            int64_t srtt = json_read_int64(json_find_key(path_obj, "srtt_ms"));
+            int64_t min_rtt = json_read_int64(json_find_key(path_obj, "min_rtt_ms"));
+            uint64_t cwnd = (uint64_t)json_read_int64(json_find_key(path_obj, "cwnd"));
+            int state = (int)json_read_int64(json_find_key(path_obj, "state"));
 
             char cwnd_str[16];
             format_size(cwnd, cwnd_str, sizeof(cwnd_str));
@@ -217,7 +166,7 @@ print_client(const char *obj)
             idx++;
         }
         if (*p == ',') p++;
-        p = skip_ws(p);
+        p = json_skip_ws(p);
     }
 }
 
@@ -303,21 +252,21 @@ run_status(const char *addr, int port)
     fd = -1;
 
     /* Parse and display */
-    const char *ok = jfind(buf, "ok");
+    const char *ok = json_find_key(buf, "ok");
     if (!ok || strncmp(ok, "true", 4) != 0) {
-        const char *err = jfind(buf, "error");
+        const char *err = json_find_key(buf, "error");
         char errmsg[128] = "unknown error";
-        if (err) jstr(err, errmsg, sizeof(errmsg));
+        if (err) json_read_string(err, errmsg, sizeof(errmsg));
         fprintf(stderr, "error: %s\n", errmsg);
         goto cleanup;
     }
 
-    int n_clients = (int)jint(jfind(buf, "n_clients"));
+    int n_clients = (int)json_read_int64(json_find_key(buf, "n_clients"));
     printf("mqvpn server  clients: %d\n", n_clients);
 
-    const char *clients = jfind(buf, "clients");
+    const char *clients = json_find_key(buf, "clients");
     if (clients && *clients == '[') {
-        const char *p = skip_ws(clients + 1);
+        const char *p = json_skip_ws(clients + 1);
         while (*p && *p != ']') {
             if (*p == '{') {
                 const char *end = skip_json_value(p);
@@ -334,7 +283,7 @@ run_status(const char *addr, int port)
                 p = end;
             }
             if (*p == ',') p++;
-            p = skip_ws(p);
+            p = json_skip_ws(p);
         }
     }
 

--- a/tests/test_status.c
+++ b/tests/test_status.c
@@ -149,32 +149,32 @@ TEST(format_size_mega)
 TEST(jfind_simple)
 {
     const char *json = "{\"name\":\"alice\",\"age\":30}";
-    const char *v = jfind(json, "name");
+    const char *v = json_find_key(json, "name");
     assert(v != NULL);
     char out[32];
-    ASSERT_EQ(jstr(v, out, sizeof(out)), 0);
+    ASSERT_EQ(json_read_string(v, out, sizeof(out)), 0);
     ASSERT_STR_EQ(out, "alice");
 }
 
 TEST(jfind_int)
 {
     const char *json = "{\"count\":42}";
-    ASSERT_EQ(jint(jfind(json, "count")), 42);
+    ASSERT_EQ(json_read_int64(json_find_key(json, "count")), 42);
 }
 
 TEST(jfind_missing)
 {
     const char *json = "{\"name\":\"alice\"}";
-    assert(jfind(json, "missing") == NULL);
+    assert(json_find_key(json, "missing") == NULL);
 }
 
 TEST(jfind_nested_value)
 {
-    /* jfind does flat search, so it finds "key" inside nested obj too */
+    /* json_find_key does flat search, so it finds "key" inside nested obj too */
     const char *json = "{\"user\":{\"key\":\"val\"},\"key\":\"top\"}";
-    const char *v = jfind(json, "key");
+    const char *v = json_find_key(json, "key");
     char out[32];
-    ASSERT_EQ(jstr(v, out, sizeof(out)), 0);
+    ASSERT_EQ(json_read_string(v, out, sizeof(out)), 0);
     /* Flat search finds first occurrence */
     ASSERT_STR_EQ(out, "val");
 }
@@ -182,12 +182,12 @@ TEST(jfind_nested_value)
 TEST(jstr_null)
 {
     char out[32];
-    ASSERT_EQ(jstr(NULL, out, sizeof(out)), -1);
+    ASSERT_EQ(json_read_string(NULL, out, sizeof(out)), -1);
 }
 
 TEST(jint_null)
 {
-    ASSERT_EQ(jint(NULL), 0);
+    ASSERT_EQ(json_read_int64(NULL), 0);
 }
 
 /* ── skip_json_value tests ── */


### PR DESCRIPTION
- Create src/json_mini.h with static inline helpers: json_skip_ws, json_find_key, json_read_string, json_read_bool, json_read_int, json_read_int64, mqvpn_copy_str
- Remove duplicated functions 