### PR TITLE
ci: add ASan + UBSan sanitizer job with unit + E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,119 @@ jobs:
             build/cmake_install.cmake
           retention-days: 1
 
+  sanitizer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake libevent-dev golang iptables clang
+
+      - name: Clone BoringSSL (pinned)
+        run: |
+          git clone https://github.com/google/boringssl.git \
+            third_party/xquic/third_party/boringssl
+          cd third_party/xquic/third_party/boringssl && git checkout 9c95ec797c65fde9e8ddffc3888f0b8c1460fe4c
+
+      - name: Build BoringSSL (clang)
+        run: |
+          cd third_party/xquic/third_party/boringssl
+          mkdir -p build && cd build
+          CC=clang CXX=clang++ cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
+          make -j$(nproc) ssl crypto
+
+      - name: Build xquic (clang)
+        run: |
+          cd third_party/xquic
+          mkdir -p build && cd build
+          CC=clang cmake -DCMAKE_BUILD_TYPE=Debug -DSSL_TYPE=boringssl \
+                -DXQC_ENABLE_BBR2=ON \
+                -DCMAKE_C_FLAGS="-Wno-unknown-warning-option" ..
+          make -j$(nproc)
+
+      - name: Build mqvpn (clang + ASan + UBSan)
+        run: |
+          mkdir -p build && cd build
+          CC=clang cmake -DCMAKE_BUILD_TYPE=Debug \
+                -DENABLE_SANITIZERS=ON \
+                -DXQUIC_BUILD_DIR=../third_party/xquic/build ..
+          make -j$(nproc)
+
+      - name: Unit tests (sanitizer)
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan_suppressions.txt
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: cd build && ctest --output-on-failure
+
+      - name: E2E smoke test (netns)
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan_suppressions.txt
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: sudo -E scripts/ci_e2e/run_test.sh
+
+      - name: E2E multi-client test (netns)
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan_suppressions.txt
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: sudo -E scripts/ci_e2e/test_multiclient.sh
+
+      - name: E2E NAT test (netns)
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan_suppressions.txt
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: sudo -E scripts/ci_e2e/run_nat_test.sh
+
+      - name: E2E kill switch test (netns)
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan_suppressions.txt
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: sudo -E scripts/ci_e2e/run_killswitch_test.sh
+
+      - name: E2E reconnect test (netns)
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan_suppressions.txt
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: sudo -E scripts/ci_e2e/run_reconnect_test.sh
+
+      - name: E2E IPv6 transport test (netns)
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan_suppressions.txt
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: sudo -E scripts/ci_e2e/run_ipv6_transport_test.sh
+
+      - name: E2E IPv6 data plane test (netns)
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan_suppressions.txt
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: sudo -E scripts/ci_e2e/run_ipv6_dataplane_test.sh
+
+      - name: E2E IPv6 multipath test (netns)
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan_suppressions.txt
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: sudo -E scripts/ci_e2e/run_ipv6_multipath_test.sh
+
+      - name: E2E IPv6 full multipath test (netns)
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/lsan_suppressions.txt
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: sudo -E scripts/ci_e2e/run_ipv6_full_multipath_test.sh
+
   netns-tests:
     needs: build
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # ---------- Options ----------
 option(XQUIC_BUILD_DIR "Path to pre-built xquic build directory" "")
+option(ENABLE_SANITIZERS "Enable ASan + UBSan" OFF)
+
+if(ENABLE_SANITIZERS)
+    add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer -Werror)
+    add_link_options(-fsanitize=address,undefined)
+endif()
 
 # ---------- xquic ----------
 # xquic has its own complex build system (SSL dependency, etc).

--- a/lsan_suppressions.txt
+++ b/lsan_suppressions.txt
@@ -1,0 +1,4 @@
+# LeakSanitizer suppressions for third-party code (xquic)
+# mqvpn's own leaks are NOT suppressed.
+leak:xqc_h3_ctx_create
+leak:xqc_h3_ctx_init

--- a/scripts/ci_e2e/run_ipv6_dataplane_test.sh
+++ b/scripts/ci_e2e/run_ipv6_dataplane_test.sh
@@ -19,6 +19,8 @@
 
 set -e
 
+source "$(dirname "$0")/sanitizer_check.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MQVPN="${1:-${SCRIPT_DIR}/../../build/mqvpn}"
 
@@ -51,12 +53,13 @@ NS_E="vpn-external-dp"
 
 SERVER_PID=""
 CLIENT_PID=""
+SANITIZER_FAIL=0
 
 cleanup() {
     echo ""
     echo "Cleaning up..."
-    [ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null || true
-    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+    stop_and_check_sanitizer "$CLIENT_PID" "client" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$SERVER_PID" "server" || SANITIZER_FAIL=1
     sleep 1
     # Remove iptables rules from server namespace (best-effort)
     ip netns exec "$NS_S" iptables -t nat -D POSTROUTING -s "$SUBNET" -o veth-wan-s -j MASQUERADE \
@@ -72,6 +75,10 @@ cleanup() {
     ip link del veth-c-dp 2>/dev/null || true
     ip link del veth-wan-sdp 2>/dev/null || true
     rm -rf "$WORK_DIR"
+    if [ "$SANITIZER_FAIL" -ne 0 ]; then
+        echo "FAIL: sanitizer errors detected"
+        exit 1
+    fi
 }
 trap cleanup EXIT
 

--- a/scripts/ci_e2e/run_ipv6_full_multipath_test.sh
+++ b/scripts/ci_e2e/run_ipv6_full_multipath_test.sh
@@ -20,6 +20,8 @@
 
 set -e
 
+source "$(dirname "$0")/sanitizer_check.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MQVPN=""
 LOG_LEVEL="debug"
@@ -60,18 +62,23 @@ NS_C="mp6f-client"
 
 SERVER_PID=""
 CLIENT_PID=""
+SANITIZER_FAIL=0
 
 cleanup() {
     echo ""
     echo "Cleaning up..."
-    [ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null || true
-    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+    stop_and_check_sanitizer "$CLIENT_PID" "client" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$SERVER_PID" "server" || SANITIZER_FAIL=1
     sleep 1
     ip netns del "$NS_S" 2>/dev/null || true
     ip netns del "$NS_C" 2>/dev/null || true
     ip link del veth-a0-6f 2>/dev/null || true
     ip link del veth-b0-6f 2>/dev/null || true
     rm -rf "$WORK_DIR"
+    if [ "$SANITIZER_FAIL" -ne 0 ]; then
+        echo "FAIL: sanitizer errors detected"
+        exit 1
+    fi
 }
 trap cleanup EXIT
 

--- a/scripts/ci_e2e/run_ipv6_multipath_test.sh
+++ b/scripts/ci_e2e/run_ipv6_multipath_test.sh
@@ -17,6 +17,8 @@
 
 set -e
 
+source "$(dirname "$0")/sanitizer_check.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MQVPN=""
 LOG_LEVEL="debug"
@@ -57,18 +59,23 @@ NS_C="mp6-client"
 
 SERVER_PID=""
 CLIENT_PID=""
+SANITIZER_FAIL=0
 
 cleanup() {
     echo ""
     echo "Cleaning up..."
-    [ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null || true
-    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+    stop_and_check_sanitizer "$CLIENT_PID" "client" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$SERVER_PID" "server" || SANITIZER_FAIL=1
     sleep 1
     ip netns del "$NS_S" 2>/dev/null || true
     ip netns del "$NS_C" 2>/dev/null || true
     ip link del veth-a0-6 2>/dev/null || true
     ip link del veth-b0-6 2>/dev/null || true
     rm -rf "$WORK_DIR"
+    if [ "$SANITIZER_FAIL" -ne 0 ]; then
+        echo "FAIL: sanitizer errors detected"
+        exit 1
+    fi
 }
 trap cleanup EXIT
 

--- a/scripts/ci_e2e/run_ipv6_transport_test.sh
+++ b/scripts/ci_e2e/run_ipv6_transport_test.sh
@@ -17,6 +17,8 @@
 
 set -e
 
+source "$(dirname "$0")/sanitizer_check.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MQVPN="${1:-${SCRIPT_DIR}/../../build/mqvpn}"
 
@@ -44,12 +46,13 @@ IPTABLES_COMMENT="mqvpn-ipv6-test:$$"
 
 SERVER_PID=""
 CLIENT_PID=""
+SANITIZER_FAIL=0
 
 cleanup() {
     echo ""
     echo "Cleaning up..."
-    [ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null || true
-    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+    stop_and_check_sanitizer "$CLIENT_PID" "client" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$SERVER_PID" "server" || SANITIZER_FAIL=1
     sleep 1
     # Remove iptables rules from server namespace (best-effort)
     ip netns exec vpn-server6 iptables -t nat -D POSTROUTING -s "$SUBNET" -o veth-wan-s -j MASQUERADE \
@@ -65,6 +68,10 @@ cleanup() {
     ip link del veth-c6 2>/dev/null || true
     ip link del veth-wan-s6 2>/dev/null || true
     rm -rf "$WORK_DIR"
+    if [ "$SANITIZER_FAIL" -ne 0 ]; then
+        echo "FAIL: sanitizer errors detected"
+        exit 1
+    fi
 }
 trap cleanup EXIT
 

--- a/scripts/ci_e2e/run_killswitch_test.sh
+++ b/scripts/ci_e2e/run_killswitch_test.sh
@@ -15,6 +15,8 @@
 
 set -e
 
+source "$(dirname "$0")/sanitizer_check.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MQVPN="${1:-${SCRIPT_DIR}/../../build/mqvpn}"
 
@@ -42,12 +44,13 @@ IPTABLES_COMMENT="mqvpn-ks-test:$$"
 
 SERVER_PID=""
 CLIENT_PID=""
+SANITIZER_FAIL=0
 
 cleanup() {
     echo ""
     echo "Cleaning up..."
-    [ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null || true
-    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+    stop_and_check_sanitizer "$CLIENT_PID" "client" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$SERVER_PID" "server" || SANITIZER_FAIL=1
     sleep 1
     # Remove iptables rules from server namespace (best-effort)
     ip netns exec vpn-server iptables -t nat -D POSTROUTING -s "$SUBNET" -o veth-wan-s -j MASQUERADE \
@@ -65,6 +68,10 @@ cleanup() {
     ip link del veth-c 2>/dev/null || true
     ip link del veth-wan-s 2>/dev/null || true
     rm -rf "$WORK_DIR"
+    if [ "$SANITIZER_FAIL" -ne 0 ]; then
+        echo "FAIL: sanitizer errors detected"
+        exit 1
+    fi
 }
 trap cleanup EXIT
 

--- a/scripts/ci_e2e/run_nat_test.sh
+++ b/scripts/ci_e2e/run_nat_test.sh
@@ -15,6 +15,8 @@
 
 set -e
 
+source "$(dirname "$0")/sanitizer_check.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MQVPN="${1:-${SCRIPT_DIR}/../../build/mqvpn}"
 
@@ -42,12 +44,13 @@ IPTABLES_COMMENT="mqvpn-nat-test:$$"
 
 SERVER_PID=""
 CLIENT_PID=""
+SANITIZER_FAIL=0
 
 cleanup() {
     echo ""
     echo "Cleaning up..."
-    [ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null || true
-    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+    stop_and_check_sanitizer "$CLIENT_PID" "client" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$SERVER_PID" "server" || SANITIZER_FAIL=1
     sleep 1
     # Remove iptables rules from server namespace (best-effort)
     ip netns exec vpn-server iptables -t nat -D POSTROUTING -s "$SUBNET" -o veth-wan-s -j MASQUERADE \
@@ -63,6 +66,10 @@ cleanup() {
     ip link del veth-c 2>/dev/null || true
     ip link del veth-wan-s 2>/dev/null || true
     rm -rf "$WORK_DIR"
+    if [ "$SANITIZER_FAIL" -ne 0 ]; then
+        echo "FAIL: sanitizer errors detected"
+        exit 1
+    fi
 }
 trap cleanup EXIT
 

--- a/scripts/ci_e2e/run_reconnect_test.sh
+++ b/scripts/ci_e2e/run_reconnect_test.sh
@@ -21,6 +21,8 @@
 
 set -e
 
+source "$(dirname "$0")/sanitizer_check.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MQVPN="${1:-${SCRIPT_DIR}/../../build/mqvpn}"
 
@@ -51,12 +53,13 @@ NS_EXT="vpn-external-rc"
 
 SERVER_PID=""
 CLIENT_PID=""
+SANITIZER_FAIL=0
 
 cleanup() {
     echo ""
     echo "Cleaning up..."
-    [ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null || true
-    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+    stop_and_check_sanitizer "$CLIENT_PID" "client" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$SERVER_PID" "server" || SANITIZER_FAIL=1
     sleep 1
     # Remove iptables rules from server namespace (best-effort)
     ip netns exec "$NS_SVR" iptables -t nat -D POSTROUTING -s "$SUBNET" -o veth-wan-s -j MASQUERADE \
@@ -72,6 +75,10 @@ cleanup() {
     ip link del veth-c 2>/dev/null || true
     ip link del veth-wan-s 2>/dev/null || true
     rm -rf "$WORK_DIR"
+    if [ "$SANITIZER_FAIL" -ne 0 ]; then
+        echo "FAIL: sanitizer errors detected"
+        exit 1
+    fi
 }
 trap cleanup EXIT
 

--- a/scripts/ci_e2e/run_test.sh
+++ b/scripts/ci_e2e/run_test.sh
@@ -8,6 +8,8 @@
 
 set -e
 
+source "$(dirname "$0")/sanitizer_check.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MQVPN=""
 LOG_LEVEL="debug"
@@ -41,18 +43,23 @@ openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
     -days 365 -nodes -subj "/CN=mqvpn-test" 2>/dev/null
 
 CLIENT_STRICT_PID=""
+SANITIZER_FAIL=0
 
 cleanup() {
     echo ""
     echo "Cleaning up..."
-    kill "$CLIENT_STRICT_PID" 2>/dev/null || true
-    kill "$SERVER_PID" 2>/dev/null || true
-    kill "$CLIENT_PID" 2>/dev/null || true
+    stop_and_check_sanitizer "$CLIENT_STRICT_PID" "client-strict" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$SERVER_PID" "server" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$CLIENT_PID" "client" || SANITIZER_FAIL=1
     sleep 1
     ip netns del vpn-server 2>/dev/null || true
     ip netns del vpn-client 2>/dev/null || true
     ip link del veth-c 2>/dev/null || true
     rm -rf "$WORK_DIR"
+    if [ "$SANITIZER_FAIL" -ne 0 ]; then
+        echo "FAIL: sanitizer errors detected"
+        exit 1
+    fi
 }
 trap cleanup EXIT
 

--- a/scripts/ci_e2e/sanitizer_check.sh
+++ b/scripts/ci_e2e/sanitizer_check.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# sanitizer_check.sh — Check if a process exited cleanly (no sanitizer errors)
+#
+# Usage: source sanitizer_check.sh
+#        stop_and_check_sanitizer PID "description"
+#
+# Sends SIGTERM, waits, checks exit code. ASan/UBSan cause non-zero exit.
+# Exit code 1 = sanitizer error detected.
+
+stop_and_check_sanitizer() {
+    local pid="$1"
+    local desc="${2:-process}"
+    local rc=0
+
+    if [ -z "$pid" ]; then return 0; fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+        # Already dead — check if it died from sanitizer
+        wait "$pid" 2>/dev/null
+        rc=$?
+        if [ $rc -ne 0 ]; then
+            echo "SANITIZER FAIL: $desc (PID $pid) exited with code $rc"
+            return 1
+        fi
+        return 0
+    fi
+
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null
+    rc=$?
+
+    # SIGTERM causes exit code 143 (128+15) which is normal
+    if [ $rc -ne 0 ] && [ $rc -ne 143 ]; then
+        echo "SANITIZER FAIL: $desc (PID $pid) exited with code $rc"
+        return 1
+    fi
+    return 0
+}

--- a/scripts/ci_e2e/test_multiclient.sh
+++ b/scripts/ci_e2e/test_multiclient.sh
@@ -11,6 +11,8 @@
 
 set -e
 
+source "$(dirname "$0")/sanitizer_check.sh"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MQVPN="${1:-${SCRIPT_DIR}/../../build/mqvpn}"
 
@@ -38,13 +40,16 @@ CLIENT1_PID=""
 CLIENT2_PID=""
 CLIENT3_PID=""
 CLIENT_BAD_PID=""
+SANITIZER_FAIL=0
 
 cleanup() {
     echo ""
     echo "Cleaning up..."
-    for pid in $CLIENT_BAD_PID $CLIENT3_PID $CLIENT2_PID $CLIENT1_PID $SERVER_PID; do
-        kill "$pid" 2>/dev/null || true
-    done
+    stop_and_check_sanitizer "$CLIENT_BAD_PID" "client-bad" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$CLIENT3_PID" "client3" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$CLIENT2_PID" "client2" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$CLIENT1_PID" "client1" || SANITIZER_FAIL=1
+    stop_and_check_sanitizer "$SERVER_PID" "server" || SANITIZER_FAIL=1
     sleep 1
     for ns in mc-client1 mc-client2 mc-client3 mc-client-bad mc-server; do
         ip netns del "$ns" 2>/dev/null || true
@@ -53,6 +58,10 @@ cleanup() {
         ip link del "$link" 2>/dev/null || true
     done
     rm -rf "$WORK_DIR"
+    if [ "$SANITIZER_FAIL" -ne 0 ]; then
+        echo "FAIL: sanitizer errors detected"
+        exit 1
+    fi
 }
 trap cleanup EXIT
 

--- a/src/mqvpn_client.c
+++ b/src/mqvpn_client.c
@@ -1259,7 +1259,8 @@ cli_start_connection(mqvpn_client_t *c)
         goto cleanup;
     }
 
-    memcpy(&conn->cid, cid, sizeof(*cid));
+    /* cid may be misaligned inside xquic's internal structures */
+    memcpy(&conn->cid, (const void *)cid, sizeof(conn->cid));
     if (conn->h3_conn) xqc_h3_ext_datagram_set_user_data(conn->h3_conn, conn);
 
     /* Mark primary path */

--- a/src/mqvpn_server.c
+++ b/src/mqvpn_server.c
@@ -871,7 +871,8 @@ cb_h3_conn_create(xqc_h3_conn_t *h3_conn, const xqc_cid_t *cid, void *conn_user_
     if (!conn) return -1;
     conn->server = s;
     conn->h3_conn = h3_conn;
-    memcpy(&conn->cid, cid, sizeof(*cid));
+    /* cid may be misaligned inside xquic's internal structures */
+    memcpy(&conn->cid, (const void *)cid, sizeof(conn->cid));
 
     xqc_h3_conn_set_user_data(h3_conn, conn);
     xqc_h3_ext_datagram_set_user_data(h3_conn, conn);


### PR DESCRIPTION
- Add ENABLE_SANITIZERS cmake option (-fsanitize=address,undefined+ -fno-omit-frame-pointer + -Werror)
- Add sanitizer CI job: Debug build with sanitizers, runs ctest and all 9 netns E2E tests under ASan + UBSan
- Add lsan_suppressions.txt to suppress known xquic leaks (xqc_h3_ctx_init) while detecting mqvpn leaks