### PR TITLE
fix(multipath): restore path recovery after link failure

### DIFF
--- a/benchmarks/bench_failover.sh
+++ b/benchmarks/bench_failover.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
-# bench_failover.sh — Netns failover TTR (Time-To-Recovery) measurement
+# bench_failover.sh — Netns failover benchmark (TTF + TTR)
 #
-# Runs a 60-second iperf3 transfer over multipath VPN, injects a path
-# failure at t=20s, recovers at t=40s, and measures how long throughput
-# takes to recover to 90% of pre-fault average.
+# Runs a 75-second iperf3 transfer over multipath VPN, injects a path
+# failure at t=20s, recovers at t=40s, and measures:
+#   TTF: time from fault to surviving path reaching 50% capacity
+#   TTR: time from recovery to 80% of pre-fault throughput
+#   Degraded: average during fault (t=20-40)
+#   Post-recover: last 10s (t=65-75, after path revalidation)
+#
+# Both client and server sides of the faulted path are brought down.
+# On recovery: link up + IP re-add + netem re-apply on both ends.
 #
 # Output: bench_results/failover_netns_<timestamp>.json
 #
-# Usage: sudo ./bench_failover.sh [-s scheduler] [-p a|b] [-P streams] [path-to-mqvpn-binary]
-#   -s  Scheduler: wlb or minrtt (default: wlb)
-#   -p  Fault path to inject/recover: a or b (default: a)
-#   -P  iperf3 parallel streams (default: 4)
+# Usage: sudo ./bench_failover.sh [-s scheduler] [-p a|b] [-P streams] [-l loglevel] [mqvpn-binary]
 
 set -e
 
@@ -20,12 +23,13 @@ source "${SCRIPT_DIR}/bench_env_setup.sh"
 FAULT_PATH="${FAULT_PATH:-a}"
 IPERF_PARALLEL="${IPERF_PARALLEL:-4}"
 
-while getopts "s:p:P:" opt; do
+while getopts "s:p:P:l:" opt; do
     case "$opt" in
         s) BENCH_SCHEDULER="$OPTARG" ;;
         p) FAULT_PATH="$OPTARG" ;;
         P) IPERF_PARALLEL="$OPTARG" ;;
-        *) echo "Usage: $0 [-s scheduler] [-p a|b] [-P streams] [mqvpn-binary]"; exit 1 ;;
+        l) BENCH_LOG_LEVEL="$OPTARG" ;;
+        *) echo "Usage: $0 [-s scheduler] [-p a|b] [-P streams] [-l loglevel] [mqvpn-binary]"; exit 1 ;;
     esac
 done
 shift $((OPTIND - 1))
@@ -35,14 +39,17 @@ case "$FAULT_PATH" in
         FAULT_PATH_LABEL="A"
         FAULT_IF_CLIENT="$VETH_A0"
         FAULT_IF_SERVER="$VETH_A1"
-        FAULT_SERVER_IP_CIDR="$IP_A_SERVER"
+        FAULT_IP_CLIENT="$IP_A_CLIENT"
+        FAULT_IP_SERVER="$IP_A_SERVER"
+        FAULT_NETEM="delay 10ms rate 300mbit"
         ;;
     b|B)
-        FAULT_PATH="b"
         FAULT_PATH_LABEL="B"
         FAULT_IF_CLIENT="$VETH_B0"
         FAULT_IF_SERVER="$VETH_B1"
-        FAULT_SERVER_IP_CIDR="$IP_B_SERVER"
+        FAULT_IP_CLIENT="$IP_B_CLIENT"
+        FAULT_IP_SERVER="$IP_B_SERVER"
+        FAULT_NETEM="delay 30ms rate 80mbit"
         ;;
     *)
         echo "error: invalid fault path '$FAULT_PATH' (expected a or b)"
@@ -50,34 +57,32 @@ case "$FAULT_PATH" in
         ;;
 esac
 
-case "$IPERF_PARALLEL" in
-    ''|*[!0-9]*)
-        echo "error: invalid -P '$IPERF_PARALLEL' (expected positive integer)"
-        exit 1
-        ;;
-esac
-if [ "$IPERF_PARALLEL" -lt 1 ]; then
-    echo "error: invalid -P '$IPERF_PARALLEL' (expected >= 1)"
-    exit 1
-fi
-
 MQVPN="${1:-${MQVPN}}"
-DURATION=60
+DURATION=75
 INTERVAL=0.5
 FAULT_INJECT_SEC=20
 FAULT_RECOVER_SEC=40
 IPERF_SERVER_PID=""
+
+# Stale cleanup
+pkill -f "mqvpn.*bench" 2>/dev/null || true
+ip netns del "$NS_SERVER" 2>/dev/null || true
+ip netns del "$NS_CLIENT" 2>/dev/null || true
+ip link del "$VETH_A0" 2>/dev/null || true
+ip link del "$VETH_B0" 2>/dev/null || true
 
 trap bench_cleanup EXIT
 
 bench_check_deps
 
 echo "================================================================"
-echo "  mqvpn Failover TTR Benchmark (netns)"
+echo "  mqvpn Failover Benchmark (TTF + TTR)"
 echo "  Binary:    $MQVPN"
 echo "  Scheduler: $BENCH_SCHEDULER"
 echo "  FaultPath: ${FAULT_PATH_LABEL}"
 echo "  Streams:   ${IPERF_PARALLEL}"
+echo "  Duration:  ${DURATION}s"
+echo "  LogLevel:  ${BENCH_LOG_LEVEL}"
 echo "  Date:      $(date '+%Y-%m-%d %H:%M')"
 echo "================================================================"
 
@@ -95,7 +100,7 @@ sleep 1
 
 # --- iperf3 client (background, JSON output) ---
 IPERF_JSON="$(mktemp)"
-echo "Starting iperf3 for ${DURATION}s (interval=${INTERVAL}s, JSON)..."
+echo "Starting iperf3 for ${DURATION}s (interval=${INTERVAL}s, -P ${IPERF_PARALLEL}, JSON)..."
 ip netns exec "$NS_CLIENT" iperf3 \
     -c "$TUNNEL_SERVER_IP" -t "$DURATION" \
     -P "$IPERF_PARALLEL" \
@@ -105,15 +110,20 @@ IPERF_CLIENT_PID=$!
 
 # --- Fault injection at t=20s ---
 sleep "$FAULT_INJECT_SEC"
-echo "[$(date +%T)] FAULT INJECT: bringing down $FAULT_IF_SERVER (Path ${FAULT_PATH_LABEL} server-side)"
+echo "[$(date +%T)] FAULT INJECT: Path ${FAULT_PATH_LABEL} down (both ends)"
+ip netns exec "$NS_CLIENT" ip link set "$FAULT_IF_CLIENT" down
 ip netns exec "$NS_SERVER" ip link set "$FAULT_IF_SERVER" down
 
 # --- Fault recovery at t=40s ---
 WAIT_RECOVER=$((FAULT_RECOVER_SEC - FAULT_INJECT_SEC))
 sleep "$WAIT_RECOVER"
-echo "[$(date +%T)] FAULT RECOVER: bringing up $FAULT_IF_SERVER (Path ${FAULT_PATH_LABEL} server-side)"
+echo "[$(date +%T)] FAULT RECOVER: Path ${FAULT_PATH_LABEL} up (both ends)"
+ip netns exec "$NS_CLIENT" ip link set "$FAULT_IF_CLIENT" up
 ip netns exec "$NS_SERVER" ip link set "$FAULT_IF_SERVER" up
-ip netns exec "$NS_SERVER" ip addr add "$FAULT_SERVER_IP_CIDR" dev "$FAULT_IF_SERVER" 2>/dev/null || true
+ip netns exec "$NS_CLIENT" ip addr add "$FAULT_IP_CLIENT" dev "$FAULT_IF_CLIENT" 2>/dev/null || true
+ip netns exec "$NS_SERVER" ip addr add "$FAULT_IP_SERVER" dev "$FAULT_IF_SERVER" 2>/dev/null || true
+ip netns exec "$NS_CLIENT" tc qdisc add dev "$FAULT_IF_CLIENT" root netem ${FAULT_NETEM} 2>/dev/null || true
+ip netns exec "$NS_SERVER" tc qdisc add dev "$FAULT_IF_SERVER" root netem ${FAULT_NETEM} 2>/dev/null || true
 
 # --- Wait for iperf3 to finish ---
 echo "Waiting for iperf3 to complete..."
@@ -121,7 +131,7 @@ wait "$IPERF_CLIENT_PID" || true
 wait "$IPERF_SERVER_PID" 2>/dev/null || true
 IPERF_SERVER_PID=""
 
-# --- Parse iperf3 JSON and produce output ---
+# --- Parse iperf3 JSON ---
 TIMESTAMP="$(date -Iseconds)"
 OUTPUT_FILE="${RESULTS_DIR}/failover_netns_$(date +%Y%m%d_%H%M%S).json"
 
@@ -131,7 +141,6 @@ import json, sys
 with open('${IPERF_JSON}') as f:
     raw = json.load(f)
 
-# Extract intervals
 intervals = []
 for iv in raw.get('intervals', []):
     s = iv['sum']
@@ -142,24 +151,36 @@ for iv in raw.get('intervals', []):
 
 fault_inject = ${FAULT_INJECT_SEC}
 fault_recover = ${FAULT_RECOVER_SEC}
+duration = ${DURATION}
 
-# Pre-fault average (intervals before fault injection)
+# Pre-fault average (both paths active)
 pre_fault = [iv['mbps'] for iv in intervals if iv['time_sec'] <= fault_inject]
 pre_fault_avg = sum(pre_fault) / len(pre_fault) if pre_fault else 0
 
-# TTR (fallback): time from fault injection until goodput recovers to 90%
-# of pre-fault avg on the surviving path(s). This measures how quickly
-# the scheduler shifts traffic away from the failed path, NOT full
-# recovery after path restoration.
-threshold = pre_fault_avg * 0.9
-ttr = None
+# Degraded average (during fault, surviving path only)
+degraded = [iv['mbps'] for iv in intervals
+            if iv['time_sec'] > fault_inject and iv['time_sec'] <= fault_recover]
+degraded_avg = sum(degraded) / len(degraded) if degraded else 0
+
+# TTF: time from fault to surviving path reaching 50% capacity
+surviving_path_mbps = 80 if '${FAULT_PATH_LABEL}' == 'A' else 300
+ttf_threshold = surviving_path_mbps * 0.5
+ttf = None
 for iv in intervals:
-    if iv['time_sec'] > fault_inject and iv['mbps'] >= threshold:
-        ttr = round(iv['time_sec'] - fault_inject, 2)
+    if iv['time_sec'] > fault_inject and iv['mbps'] >= ttf_threshold:
+        ttf = round(iv['time_sec'] - fault_inject, 2)
         break
 
-# Post-recover average (intervals after fault_recover + 2s settling)
-post_recover = [iv['mbps'] for iv in intervals if iv['time_sec'] > fault_recover + 2]
+# TTR: time from recovery to 80% of pre-fault (path revalidation)
+ttr_threshold = pre_fault_avg * 0.8
+ttr = None
+for iv in intervals:
+    if iv['time_sec'] > fault_recover and iv['mbps'] >= ttr_threshold:
+        ttr = round(iv['time_sec'] - fault_recover, 2)
+        break
+
+# Post-recover average (last 10s)
+post_recover = [iv['mbps'] for iv in intervals if iv['time_sec'] > duration - 10]
 post_recover_avg = sum(post_recover) / len(post_recover) if post_recover else 0
 
 result = {
@@ -178,8 +199,9 @@ result = {
     'fault_recover_sec': fault_recover,
     'intervals': intervals,
     'pre_fault_avg_mbps': round(pre_fault_avg, 1),
+    'degraded_avg_mbps': round(degraded_avg, 1),
+    'ttf_sec': ttf,
     'ttr_sec': ttr,
-    'ttr_definition': 'seconds from fault injection until throughput reaches 90% of pre-fault avg (fallback to surviving path)',
     'post_recover_avg_mbps': round(post_recover_avg, 1)
 }
 
@@ -187,6 +209,8 @@ with open('${OUTPUT_FILE}', 'w') as f:
     json.dump(result, f, indent=2)
 
 print(f'Pre-fault avg:     {pre_fault_avg:.1f} Mbps')
+print(f'Degraded avg:      {degraded_avg:.1f} Mbps')
+print(f'TTF:               {ttf} sec')
 print(f'TTR:               {ttr} sec')
 print(f'Post-recover avg:  {post_recover_avg:.1f} Mbps')
 "

--- a/include/libmqvpn.h
+++ b/include/libmqvpn.h
@@ -40,12 +40,12 @@ extern "C" {
 
 /* ─── ABI ─── */
 
-#define MQVPN_CALLBACKS_ABI_VERSION  2
+#define MQVPN_CALLBACKS_ABI_VERSION 2
 
 /* ─── Capacity constants ─── */
 
-#define MQVPN_MAX_USERS   64
-#define MQVPN_MAX_PATHS    4
+#define MQVPN_MAX_USERS 64
+#define MQVPN_MAX_PATHS 4
 
 /* ─── Opaque handles ─── */
 
@@ -61,16 +61,17 @@ typedef enum {
     MQVPN_OK = 0,
     MQVPN_ERR_INVALID_ARG = -1,
     MQVPN_ERR_NO_MEMORY = -2,
-    MQVPN_ERR_ENGINE = -3,        /* xquic engine error */
-    MQVPN_ERR_TLS = -4,           /* TLS handshake failure */
-    MQVPN_ERR_AUTH = -5,          /* PSK auth failure (403) */
-    MQVPN_ERR_PROTOCOL = -6,      /* MASQUE not supported */
-    MQVPN_ERR_POOL_FULL = -7,     /* server: IP pool exhausted */
-    MQVPN_ERR_MAX_CLIENTS = -8,   /* server: max clients reached */
-    MQVPN_ERR_AGAIN = -9,         /* back-pressure */
-    MQVPN_ERR_CLOSED = -10,       /* connection closed */
-    MQVPN_ERR_ABI_MISMATCH = -11, /* callback ABI version mismatch */
-    MQVPN_ERR_TIMEOUT = -12,      /* connection timeout */
+    MQVPN_ERR_ENGINE = -3,         /* xquic engine error */
+    MQVPN_ERR_TLS = -4,            /* TLS handshake failure */
+    MQVPN_ERR_AUTH = -5,           /* PSK auth failure (403) */
+    MQVPN_ERR_PROTOCOL = -6,       /* MASQUE not supported */
+    MQVPN_ERR_POOL_FULL = -7,      /* server: IP pool exhausted */
+    MQVPN_ERR_MAX_CLIENTS = -8,    /* server: max clients reached */
+    MQVPN_ERR_AGAIN = -9,          /* back-pressure */
+    MQVPN_ERR_CLOSED = -10,        /* connection closed */
+    MQVPN_ERR_ABI_MISMATCH = -11,  /* callback ABI version mismatch */
+    MQVPN_ERR_TIMEOUT = -12,       /* connection timeout */
+    MQVPN_ERR_INVALID_STATE = -13, /* operation not valid in current state */
 } mqvpn_error_t;
 
 /* ─── Enumerations ─── */
@@ -106,6 +107,17 @@ typedef enum {
     MQVPN_STATE__COUNT = 7,
 } mqvpn_client_state_t;
 
+/*
+ * Path lifecycle:
+ *   active  = platform owns this path slot, fd is valid
+ *   in_use  = xquic has a live QUIC path on this slot
+ *
+ *   PENDING   → add_path_fd() called, awaiting activation
+ *   ACTIVE    → xquic path created (validation async)
+ *   DEGRADED  → transport failed, library timer retries with backoff (5s→60s, max 6)
+ *   CLOSED    → retries exhausted (platform can still call reactivate_path if active==1)
+ *              OR explicitly removed via remove_path() (active==0, no recovery)
+ */
 typedef enum {
     MQVPN_PATH_PENDING = 0,
     MQVPN_PATH_ACTIVE = 1,
@@ -161,7 +173,7 @@ typedef struct {
     uint64_t pkt_sent;
     uint64_t pkt_recv;
     uint64_t pkt_lost;
-    uint8_t  state;
+    uint8_t state;
 } mqvpn_path_stats_t;
 
 typedef struct {
@@ -282,17 +294,12 @@ _Static_assert(offsetof(mqvpn_server_callbacks_t, abi_version) == 0,
 MQVPN_API mqvpn_config_t *mqvpn_config_new(void);
 MQVPN_API void mqvpn_config_free(mqvpn_config_t *cfg);
 
-MQVPN_API int mqvpn_config_set_server(mqvpn_config_t *cfg,
-                                       const char *host, int port);
-MQVPN_API int mqvpn_config_set_auth_key(mqvpn_config_t *cfg,
-                                         const char *key);
-MQVPN_API int mqvpn_config_add_user(mqvpn_config_t *cfg,
-                                     const char *username,
-                                     const char *key);
-MQVPN_API int mqvpn_config_remove_user(mqvpn_config_t *cfg,
-                                        const char *username);
-MQVPN_API int mqvpn_config_load_json(mqvpn_config_t *cfg,
-                                      const char *json_text);
+MQVPN_API int mqvpn_config_set_server(mqvpn_config_t *cfg, const char *host, int port);
+MQVPN_API int mqvpn_config_set_auth_key(mqvpn_config_t *cfg, const char *key);
+MQVPN_API int mqvpn_config_add_user(mqvpn_config_t *cfg, const char *username,
+                                    const char *key);
+MQVPN_API int mqvpn_config_remove_user(mqvpn_config_t *cfg, const char *username);
+MQVPN_API int mqvpn_config_load_json(mqvpn_config_t *cfg, const char *json_text);
 MQVPN_API int mqvpn_config_set_insecure(mqvpn_config_t *cfg, int insecure);
 MQVPN_API int mqvpn_config_set_scheduler(mqvpn_config_t *cfg, mqvpn_scheduler_t sched);
 MQVPN_API int mqvpn_config_set_log_level(mqvpn_config_t *cfg, mqvpn_log_level_t level);
@@ -329,6 +336,22 @@ MQVPN_API mqvpn_path_handle_t mqvpn_client_add_path_fd(mqvpn_client_t *client, i
                                                        const mqvpn_path_desc_t *desc);
 
 MQVPN_API int mqvpn_client_remove_path(mqvpn_client_t *client, mqvpn_path_handle_t path);
+
+/*
+ * Re-activate a DEGRADED or CLOSED path using the existing fd.
+ * Called by the platform layer when it detects the path is viable again
+ * (e.g., netlink RTM_NEWADDR on Linux, ConnectivityManager on Android).
+ *
+ * Preconditions: !in_use && active && (DEGRADED || CLOSED).
+ * On success: xquic creates a new path (validation is async). The library
+ * recovery timer is cancelled. Retry counter resets after 30s stability.
+ *
+ * Returns MQVPN_OK, MQVPN_ERR_INVALID_ARG, MQVPN_ERR_INVALID_STATE, or
+ * MQVPN_ERR_ENGINE.
+ * Thread safety: must be called from the tick thread (same as all other APIs).
+ */
+MQVPN_API int mqvpn_client_reactivate_path(mqvpn_client_t *client,
+                                           mqvpn_path_handle_t path);
 
 MQVPN_API int mqvpn_client_set_tun_active(mqvpn_client_t *client, int active, int tun_fd);
 
@@ -390,20 +413,19 @@ MQVPN_API int mqvpn_server_get_interest(const mqvpn_server_t *server,
 
 MQVPN_API int mqvpn_server_get_n_clients(const mqvpn_server_t *server);
 
-MQVPN_API int mqvpn_server_add_user(mqvpn_server_t *server,
-                                     const char *username, const char *key);
+MQVPN_API int mqvpn_server_add_user(mqvpn_server_t *server, const char *username,
+                                    const char *key);
 
-MQVPN_API int mqvpn_server_remove_user(mqvpn_server_t *server,
-                                        const char *username);
+MQVPN_API int mqvpn_server_remove_user(mqvpn_server_t *server, const char *username);
 
 /* Fill names[0..max-1] with current user names. Returns the count. */
-MQVPN_API int mqvpn_server_list_users(const mqvpn_server_t *server,
-                                       char names[][64], int max);
+MQVPN_API int mqvpn_server_list_users(const mqvpn_server_t *server, char names[][64],
+                                      int max);
 
 /* Fill out[0..max-1] with per-client info including per-path stats. */
 MQVPN_API int mqvpn_server_get_client_info(const mqvpn_server_t *server,
-                                            mqvpn_client_info_t *out,
-                                            int max_clients, int *n_clients);
+                                           mqvpn_client_info_t *out, int max_clients,
+                                           int *n_clients);
 
 /* ─── Utility API ─── */
 

--- a/src/mqvpn_client.c
+++ b/src/mqvpn_client.c
@@ -41,12 +41,16 @@
 
 /* ─── Constants ─── */
 
-#define PACKET_BUF_SIZE           65536
-#define MASQUE_FRAME_BUF          (PACKET_BUF_SIZE + 16)
-#define MAX_CAPSULE_BUF           65536
-#define XQC_SNDQ_MAX_PKTS         16384
-#define RECONNECT_BACKOFF_MAX_SEC 60
-#define PTB_RATE_LIMIT            10
+#define PACKET_BUF_SIZE            65536
+#define MASQUE_FRAME_BUF           (PACKET_BUF_SIZE + 16)
+#define MAX_CAPSULE_BUF            65536
+#define XQC_SNDQ_MAX_PKTS          16384
+#define RECONNECT_BACKOFF_MAX_SEC  60
+#define PTB_RATE_LIMIT             10
+#define PATH_RECREATE_DELAY_US     (5ULL * 1000000)  /* 5 sec initial */
+#define PATH_RECREATE_MAX_DELAY_US (60ULL * 1000000) /* 60 sec max backoff */
+#define PATH_RECREATE_MAX_RETRIES  6                 /* max consecutive failures */
+#define PATH_STABLE_THRESHOLD_US   (30ULL * 1000000) /* 30 sec to confirm stable */
 
 /* ─── Forward declarations ─── */
 
@@ -73,6 +77,9 @@ typedef struct {
     int srtt_ms;
     uint64_t bytes_tx;
     uint64_t bytes_rx;
+    uint64_t recreate_after_us;    /* 0 = no pending timer */
+    int recreate_retries;          /* consecutive failures, reset after 30s stable */
+    uint64_t path_stable_since_us; /* non-zero = awaiting stability confirmation */
 } path_entry_t;
 
 /* Per-connection state (Level 2 — destroyed on reconnect) */
@@ -1168,6 +1175,16 @@ cb_ready_to_create_path(const xqc_cid_t *cid, void *conn_user_data)
     }
 }
 
+static uint64_t
+path_recreate_backoff(int retries)
+{
+    uint64_t delay = PATH_RECREATE_DELAY_US;
+    for (int r = 1; r < retries && delay < PATH_RECREATE_MAX_DELAY_US; r++)
+        delay *= 2;
+    if (delay > PATH_RECREATE_MAX_DELAY_US) delay = PATH_RECREATE_MAX_DELAY_US;
+    return delay;
+}
+
 static void
 cb_path_removed(const xqc_cid_t *cid, uint64_t path_id, void *conn_user_data)
 {
@@ -1180,9 +1197,31 @@ cb_path_removed(const xqc_cid_t *cid, uint64_t path_id, void *conn_user_data)
         LOG_I(c, "path removed: path_id=%" PRIu64 " iface=%s", path_id, p->name);
         p->in_use = 0;
         p->xqc_path_id = 0;
-        p->status = MQVPN_PATH_CLOSED;
-        if (c->cbs.path_event)
-            c->cbs.path_event(p->handle, MQVPN_PATH_CLOSED, c->user_ctx);
+        p->path_stable_since_us = 0; /* validation failed before stability */
+
+        if (p->active) {
+            p->recreate_retries++;
+
+            if (p->recreate_retries < PATH_RECREATE_MAX_RETRIES) {
+                p->status = MQVPN_PATH_DEGRADED;
+                uint64_t delay = path_recreate_backoff(p->recreate_retries);
+                p->recreate_after_us = client_now_us(c) + delay;
+                LOG_I(c, "path degraded: %s (retry %d/%d in %ds)", p->name,
+                      p->recreate_retries, PATH_RECREATE_MAX_RETRIES,
+                      (int)(delay / 1000000));
+            } else {
+                p->status = MQVPN_PATH_CLOSED;
+                p->recreate_after_us = 0;
+                LOG_W(c,
+                      "path closed: %s (max retries %d exhausted, "
+                      "platform can still recover)",
+                      p->name, PATH_RECREATE_MAX_RETRIES);
+            }
+        } else {
+            p->status = MQVPN_PATH_CLOSED;
+        }
+
+        if (c->cbs.path_event) c->cbs.path_event(p->handle, p->status, c->user_ctx);
     }
 }
 
@@ -1299,7 +1338,7 @@ mqvpn_client_new(const mqvpn_config_t *cfg, const mqvpn_client_callbacks_t *cbs,
     memcpy(&c->config, cfg, sizeof(*cfg));
     memcpy(&c->cbs, cbs, sizeof(*cbs));
     c->user_ctx = user_ctx;
-        /* caller guarantees lifetime exceeds this object */ // lgtm[cpp/stack-address-escape]
+    /* caller guarantees lifetime exceeds this object */ // lgtm[cpp/stack-address-escape]
     c->state = MQVPN_STATE_IDLE;
     c->next_path_handle = 1;
     c->ptb_tokens = PTB_RATE_LIMIT;
@@ -1518,8 +1557,51 @@ mqvpn_client_remove_path(mqvpn_client_t *c, mqvpn_path_handle_t path)
 
     p->status = MQVPN_PATH_CLOSED;
     p->active = 0;
+    p->recreate_after_us = 0;
+    p->recreate_retries = 0;
+    p->path_stable_since_us = 0;
     if (p->in_use && c->engine && c->conn)
         xqc_conn_close_path(c->engine, &c->conn->cid, p->xqc_path_id);
+    return MQVPN_OK;
+}
+
+/* ─── Path re-activation (platform-triggered) ─── */
+
+int
+mqvpn_client_reactivate_path(mqvpn_client_t *c, mqvpn_path_handle_t handle)
+{
+    if (!c) return MQVPN_ERR_INVALID_ARG;
+    ASSERT_TICK_THREAD(c);
+
+    if (c->state != MQVPN_STATE_ESTABLISHED || !c->multipath_ready)
+        return MQVPN_ERR_INVALID_STATE;
+
+    /* Find path by handle */
+    int idx = -1;
+    path_entry_t *p = NULL;
+    for (int i = 0; i < c->n_paths; i++) {
+        if (c->paths[i].handle == handle) {
+            idx = i;
+            p = &c->paths[i];
+            break;
+        }
+    }
+    if (!p) return MQVPN_ERR_INVALID_ARG;
+
+    if (p->in_use) return MQVPN_ERR_INVALID_STATE;
+    if (!p->active) return MQVPN_ERR_INVALID_STATE;
+    if (p->status != MQVPN_PATH_DEGRADED && p->status != MQVPN_PATH_CLOSED)
+        return MQVPN_ERR_INVALID_STATE;
+
+    LOG_I(c, "platform reactivating path: %s (was %s)", p->name,
+          p->status == MQVPN_PATH_DEGRADED ? "degraded" : "closed");
+
+    client_activate_path(c, p, idx);
+    if (!p->in_use) return MQVPN_ERR_ENGINE;
+
+    /* Success: cancel library timer, start stability timer */
+    p->recreate_after_us = 0;
+    p->path_stable_since_us = client_now_us(c);
     return MQVPN_OK;
 }
 
@@ -1639,6 +1721,50 @@ mqvpn_client_tick(mqvpn_client_t *c)
 
     if (c->engine) xqc_engine_main_logic(c->engine);
 
+    /* Path recovery timer (exponential backoff) */
+    if (c->multipath_ready && c->state == MQVPN_STATE_ESTABLISHED) {
+        uint64_t now = client_now_us(c);
+        for (int i = 0; i < c->n_paths; i++) {
+            path_entry_t *p = &c->paths[i];
+
+            /* Recovery timer: attempt re-creation for DEGRADED paths */
+            if (p->status == MQVPN_PATH_DEGRADED && p->recreate_after_us > 0 &&
+                now >= p->recreate_after_us) {
+                p->recreate_after_us = 0;
+                LOG_I(c, "path recovery attempt: %s (retry %d/%d)", p->name,
+                      p->recreate_retries, PATH_RECREATE_MAX_RETRIES);
+                client_activate_path(c, p, i);
+
+                if (p->in_use) {
+                    /* Create succeeded — start stability timer.
+                     * xquic validates async. If fail, cb_path_removed fires. */
+                    p->path_stable_since_us = now;
+                } else {
+                    /* xqc_conn_create_path() failed synchronously */
+                    p->recreate_retries++;
+                    if (p->recreate_retries >= PATH_RECREATE_MAX_RETRIES) {
+                        p->status = MQVPN_PATH_CLOSED;
+                        p->recreate_after_us = 0;
+                        LOG_W(c, "path closed: %s (retries exhausted)", p->name);
+                        if (c->cbs.path_event)
+                            c->cbs.path_event(p->handle, MQVPN_PATH_CLOSED, c->user_ctx);
+                    } else {
+                        p->recreate_after_us =
+                            now + path_recreate_backoff(p->recreate_retries);
+                    }
+                }
+            }
+
+            /* Stability confirmation: reset retry budget after 30s stable */
+            if (p->path_stable_since_us > 0 && p->in_use &&
+                now - p->path_stable_since_us >= PATH_STABLE_THRESHOLD_US) {
+                LOG_I(c, "path %s: stable for 30s, resetting retry budget", p->name);
+                p->recreate_retries = 0;
+                p->path_stable_since_us = 0;
+            }
+        }
+    }
+
     /* Reconnect timer check */
     if (c->state == MQVPN_STATE_RECONNECTING && c->reconnect_scheduled_us > 0) {
         uint64_t t = client_now_us(c);
@@ -1651,6 +1777,9 @@ mqvpn_client_tick(mqvpn_client_t *c)
             for (int i = 0; i < c->n_paths; i++) {
                 c->paths[i].in_use = 0;
                 c->paths[i].xqc_path_id = 0;
+                c->paths[i].recreate_after_us = 0;
+                c->paths[i].recreate_retries = 0;
+                c->paths[i].path_stable_since_us = 0;
             }
 
             if (cli_start_connection(c) < 0) {
@@ -1757,6 +1886,33 @@ mqvpn_client_get_interest(const mqvpn_client_t *c, mqvpn_interest_t *out)
             if (ms <= 0 || rms < ms) ms = rms;
         } else {
             ms = 1; /* reconnect is due */
+        }
+    }
+
+    /* Account for path recovery and stability timers */
+    if (c->multipath_ready && c->state == MQVPN_STATE_ESTABLISHED) {
+        uint64_t now_val = client_now_us(c);
+        for (int i = 0; i < c->n_paths; i++) {
+            const path_entry_t *p = &c->paths[i];
+            /* Recovery timer */
+            if (p->status == MQVPN_PATH_DEGRADED && p->recreate_after_us > 0) {
+                if (p->recreate_after_us > now_val) {
+                    int pms = (int)((p->recreate_after_us - now_val) / 1000);
+                    if (ms <= 0 || pms < ms) ms = pms;
+                } else {
+                    ms = 1;
+                }
+            }
+            /* Stability timer */
+            if (p->path_stable_since_us > 0 && p->in_use) {
+                uint64_t stable_at = p->path_stable_since_us + PATH_STABLE_THRESHOLD_US;
+                if (stable_at > now_val) {
+                    int sms = (int)((stable_at - now_val) / 1000);
+                    if (ms <= 0 || sms < ms) ms = sms;
+                } else {
+                    ms = 1;
+                }
+            }
         }
     }
 

--- a/src/mqvpn_util.c
+++ b/src/mqvpn_util.c
@@ -28,6 +28,7 @@ mqvpn_error_string(mqvpn_error_t err)
     case MQVPN_ERR_CLOSED: return "connection closed";
     case MQVPN_ERR_ABI_MISMATCH: return "ABI mismatch";
     case MQVPN_ERR_TIMEOUT: return "connection timeout";
+    case MQVPN_ERR_INVALID_STATE: return "invalid state";
     }
     return "unknown error";
 }

--- a/src/platform/linux/platform_internal.h
+++ b/src/platform/linux/platform_internal.h
@@ -27,7 +27,7 @@ typedef struct {
     struct event *ev_tun;
     struct event *ev_sigint;
     struct event *ev_sigterm;
-    struct event *ev_status;   /* periodic status log timer */
+    struct event *ev_status; /* periodic status log timer */
 
     /* Path manager (UDP sockets) */
     mqvpn_path_mgr_t path_mgr;
@@ -62,6 +62,12 @@ typedef struct {
 
     /* Shutdown */
     int shutting_down;
+
+    /* Netlink path recovery */
+    int nl_fd; /* netlink socket, -1 if unavailable */
+    struct event *ev_netlink;
+    int path_recoverable[MQVPN_MAX_PATHS];         /* 1 = reactivate on netlink event */
+    int path_removed_by_platform[MQVPN_MAX_PATHS]; /* 1 = platform called remove_path */
 } platform_ctx_t;
 
 /* routing.c */

--- a/src/platform/linux/platform_linux.c
+++ b/src/platform/linux/platform_linux.c
@@ -28,6 +28,9 @@ static void status_log_cb(evutil_socket_t fd, short what, void *arg);
 #include <fcntl.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <ifaddrs.h>
 
 /* ================================================================
  *  libmqvpn callbacks
@@ -118,10 +121,9 @@ cb_tunnel_config_ready(const mqvpn_tunnel_info_t *info, void *user_ctx)
     mqvpn_client_set_tun_active(p->client, 1, p->tun.fd);
 
     /* Start periodic status log */
-    if (!p->ev_status)
-        p->ev_status = evtimer_new(p->eb, status_log_cb, p);
+    if (!p->ev_status) p->ev_status = evtimer_new(p->eb, status_log_cb, p);
     if (p->ev_status) {
-        struct timeval tv = { .tv_sec = STATUS_INTERVAL_SEC };
+        struct timeval tv = {.tv_sec = STATUS_INTERVAL_SEC};
         event_add(p->ev_status, &tv);
     }
     return;
@@ -166,8 +168,9 @@ cb_state_changed(mqvpn_client_state_t old_state, mqvpn_client_state_t new_state,
      * that stale fd events don't fire ("tun read: Bad file descriptor").
      * The TUN will be recreated in cb_tunnel_config_ready on reconnect. */
     if (new_state == MQVPN_STATE_RECONNECTING || new_state == MQVPN_STATE_CLOSED) {
-        if (p->ev_status)
-            event_del(p->ev_status);  /* pause — reused on reconnect */
+        /* Reset netlink path recovery state */
+        memset(p->path_recoverable, 0, sizeof(p->path_recoverable));
+        if (p->ev_status) event_del(p->ev_status); /* pause — reused on reconnect */
         cleanup_killswitch(p);
         cleanup_routes(p);
         mqvpn_dns_restore(&p->dns);
@@ -190,10 +193,28 @@ cb_state_changed(mqvpn_client_state_t old_state, mqvpn_client_state_t new_state,
 static void
 cb_path_event(mqvpn_path_handle_t path, mqvpn_path_status_t status, void *user_ctx)
 {
-    (void)user_ctx;
+    platform_ctx_t *p = (platform_ctx_t *)user_ctx;
     static const char *snames[] = {"PENDING", "ACTIVE", "DEGRADED", "STANDBY", "CLOSED"};
     const char *sn = (status < 5) ? snames[status] : "?";
     LOG_INF("path %lld -> %s", (long long)path, sn);
+
+    /* Track recoverable paths for netlink-triggered reactivation */
+    for (int i = 0; i < p->path_mgr.n_paths; i++) {
+        if (p->lib_path_handles[i] == path) {
+            switch (status) {
+            case MQVPN_PATH_DEGRADED: p->path_recoverable[i] = 1; break;
+            case MQVPN_PATH_ACTIVE: p->path_recoverable[i] = 0; break;
+            case MQVPN_PATH_CLOSED:
+                /* CLOSED from retries exhausted (active==1): still recoverable.
+                 * CLOSED from remove_path (active==0): not recoverable.
+                 * Platform tracks its own remove_path calls. */
+                p->path_recoverable[i] = !p->path_removed_by_platform[i];
+                break;
+            default: break;
+            }
+            break;
+        }
+    }
 }
 
 static void
@@ -226,7 +247,8 @@ cb_reconnect_scheduled(int delay_sec, void *user_ctx)
 static void
 status_log_cb(evutil_socket_t fd, short what, void *arg)
 {
-    (void)fd; (void)what;
+    (void)fd;
+    (void)what;
     platform_ctx_t *p = (platform_ctx_t *)arg;
     if (!p->client) return;
 
@@ -240,28 +262,28 @@ status_log_cb(evutil_socket_t fd, short what, void *arg)
     int n_paths = 0;
     mqvpn_client_get_paths(p->client, paths, MQVPN_MAX_PATHS, &n_paths);
 
-    LOG_INF("[STATUS] state=established paths=%d tx=%" PRIu64
-            " rx=%" PRIu64 " srtt=%dms dgram_lost=%" PRIu64,
-            n_paths, stats.bytes_tx, stats.bytes_rx,
-            stats.srtt_ms, stats.dgram_lost);
+    LOG_INF("[STATUS] state=established paths=%d tx=%" PRIu64 " rx=%" PRIu64
+            " srtt=%dms dgram_lost=%" PRIu64,
+            n_paths, stats.bytes_tx, stats.bytes_rx, stats.srtt_ms, stats.dgram_lost);
 
     for (int i = 0; i < n_paths; i++) {
         const char *st_str = "unknown";
         switch (paths[i].status) {
-        case MQVPN_PATH_ACTIVE:  st_str = "active"; break;
+        case MQVPN_PATH_PENDING: st_str = "pending"; break;
+        case MQVPN_PATH_ACTIVE: st_str = "active"; break;
+        case MQVPN_PATH_DEGRADED: st_str = "degraded"; break;
         case MQVPN_PATH_STANDBY: st_str = "standby"; break;
-        case MQVPN_PATH_CLOSED:  st_str = "closed"; break;
+        case MQVPN_PATH_CLOSED: st_str = "closed"; break;
         default: break;
         }
-        LOG_INF("[STATUS]   path%d=%s srtt=%dms tx=%" PRIu64
-                " rx=%" PRIu64 " %s",
-                i, paths[i].name, paths[i].srtt_ms,
-                paths[i].bytes_tx, paths[i].bytes_rx, st_str);
+        LOG_INF("[STATUS]   path%d=%s srtt=%dms tx=%" PRIu64 " rx=%" PRIu64 " %s", i,
+                paths[i].name, paths[i].srtt_ms, paths[i].bytes_tx, paths[i].bytes_rx,
+                st_str);
     }
 
     /* Re-arm timer */
     if (p->ev_status) {
-        struct timeval tv = { .tv_sec = STATUS_INTERVAL_SEC };
+        struct timeval tv = {.tv_sec = STATUS_INTERVAL_SEC};
         event_add(p->ev_status, &tv);
     }
 }
@@ -374,6 +396,112 @@ on_signal(evutil_socket_t sig, short what, void *arg)
 }
 
 /* ================================================================
+ *  Netlink path recovery accelerator
+ * ================================================================ */
+
+/* Check if interface has an IP address (v4 or v6) */
+static int
+iface_has_ip(const char *ifname)
+{
+    struct ifaddrs *ifa_list = NULL, *ifa;
+    int found = 0;
+    if (getifaddrs(&ifa_list) < 0) return 0;
+    for (ifa = ifa_list; ifa; ifa = ifa->ifa_next) {
+        if (!ifa->ifa_addr) continue;
+        if (strcmp(ifa->ifa_name, ifname) != 0) continue;
+        if (ifa->ifa_addr->sa_family == AF_INET || ifa->ifa_addr->sa_family == AF_INET6) {
+            found = 1;
+            break;
+        }
+    }
+    freeifaddrs(ifa_list);
+    return found;
+}
+
+static void
+try_reactivate_by_ifname(platform_ctx_t *p, const char *ifname)
+{
+    for (int i = 0; i < p->path_mgr.n_paths; i++) {
+        if (!p->path_recoverable[i]) continue;
+        if (strcmp(p->path_mgr.paths[i].iface, ifname) != 0) continue;
+
+        int ret = mqvpn_client_reactivate_path(p->client, p->lib_path_handles[i]);
+        if (ret == MQVPN_OK) {
+            LOG_INF("netlink: reactivated path %s", ifname);
+            p->path_recoverable[i] = 0;
+        } else if (ret == MQVPN_ERR_INVALID_STATE) {
+            /* Already in_use or not in right state — ignore */
+        } else {
+            LOG_WRN("netlink: reactivate %s failed: %s", ifname, mqvpn_error_string(ret));
+        }
+    }
+}
+
+static void
+on_netlink_event(evutil_socket_t fd, short what, void *arg)
+{
+    (void)what;
+    platform_ctx_t *p = (platform_ctx_t *)arg;
+    char buf[8192];
+
+    ssize_t len = recv(fd, buf, sizeof(buf), 0);
+    if (len <= 0) return;
+
+    for (struct nlmsghdr *nh = (struct nlmsghdr *)buf; NLMSG_OK(nh, (size_t)len);
+         nh = NLMSG_NEXT(nh, len)) {
+        if (nh->nlmsg_type == RTM_NEWADDR) {
+            struct ifaddrmsg *ifa = (struct ifaddrmsg *)NLMSG_DATA(nh);
+            char ifname[IFNAMSIZ];
+            if (if_indextoname(ifa->ifa_index, ifname))
+                try_reactivate_by_ifname(p, ifname);
+
+        } else if (nh->nlmsg_type == RTM_NEWLINK) {
+            struct ifinfomsg *ifi = (struct ifinfomsg *)NLMSG_DATA(nh);
+            if (!(ifi->ifi_flags & IFF_UP) || !(ifi->ifi_flags & IFF_RUNNING)) continue;
+            char ifname[IFNAMSIZ];
+            if (!if_indextoname(ifi->ifi_index, ifname)) continue;
+            /* Only reactivate if interface has an IP address */
+            if (iface_has_ip(ifname)) try_reactivate_by_ifname(p, ifname);
+        }
+    }
+}
+
+static int
+setup_netlink(platform_ctx_t *p)
+{
+    p->nl_fd =
+        socket(AF_NETLINK, SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC, NETLINK_ROUTE);
+    if (p->nl_fd < 0) {
+        LOG_WRN("netlink socket failed: %s (path recovery via timer only)",
+                strerror(errno));
+        return -1;
+    }
+
+    struct sockaddr_nl sa = {
+        .nl_family = AF_NETLINK,
+        .nl_groups = RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR,
+    };
+    if (bind(p->nl_fd, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+        LOG_WRN("netlink bind failed: %s (path recovery via timer only)",
+                strerror(errno));
+        close(p->nl_fd);
+        p->nl_fd = -1;
+        return -1;
+    }
+
+    p->ev_netlink = event_new(p->eb, p->nl_fd, EV_READ | EV_PERSIST, on_netlink_event, p);
+    if (!p->ev_netlink) {
+        LOG_WRN("netlink event_new failed (OOM?)");
+        close(p->nl_fd);
+        p->nl_fd = -1;
+        return -1;
+    }
+    event_add(p->ev_netlink, NULL);
+    LOG_INF("netlink path recovery accelerator active");
+    return 0;
+}
+
+/* ================================================================
  *  Main entry point: linux_platform_run_client
  * ================================================================ */
 
@@ -384,6 +512,7 @@ linux_platform_run_client(const mqvpn_client_cfg_t *cfg)
     platform_ctx_t ctx;
     memset(&ctx, 0, sizeof(ctx));
     ctx.tun.fd = -1;
+    ctx.nl_fd = -1;
     ctx.server_port = cfg->server_port;
     ctx.killswitch_enabled = cfg->kill_switch;
 
@@ -502,6 +631,9 @@ linux_platform_run_client(const mqvpn_client_cfg_t *cfg)
         event_add(ctx.ev_udp[i], NULL);
     }
 
+    /* Netlink path recovery accelerator (non-fatal if fails) */
+    setup_netlink(&ctx);
+
     /* Signal handlers */
     ctx.ev_sigint = evsignal_new(ctx.eb, SIGINT, on_signal, &ctx);
     ctx.ev_sigterm = evsignal_new(ctx.eb, SIGTERM, on_signal, &ctx);
@@ -545,6 +677,12 @@ cleanup:
         }
     }
 
+    if (ctx.ev_netlink) {
+        event_del(ctx.ev_netlink);
+        event_free(ctx.ev_netlink);
+    }
+    if (ctx.nl_fd >= 0) close(ctx.nl_fd);
+
     if (ctx.ev_tick) {
         event_del(ctx.ev_tick);
         event_free(ctx.ev_tick);
@@ -575,18 +713,18 @@ cleanup:
  * ================================================================ */
 
 typedef struct {
-    mqvpn_server_t     *server;
-    struct event_base  *eb;
-    struct event       *ev_tick;
-    struct event       *ev_tun;
-    struct event       *ev_socket;
-    struct event       *ev_sigint;
-    struct event       *ev_sigterm;
-    mqvpn_tun_t         tun;
-    int                 tun_up;
-    int                 udp_fd;
-    int                 shutting_down;
-    ctrl_socket_t      *ctrl;
+    mqvpn_server_t *server;
+    struct event_base *eb;
+    struct event *ev_tick;
+    struct event *ev_tun;
+    struct event *ev_socket;
+    struct event *ev_sigint;
+    struct event *ev_sigterm;
+    mqvpn_tun_t tun;
+    int tun_up;
+    int udp_fd;
+    int shutting_down;
+    ctrl_socket_t *ctrl;
 } server_platform_ctx_t;
 
 static void svr_on_tick(evutil_socket_t fd, short what, void *arg);
@@ -913,10 +1051,9 @@ linux_platform_run_server(const mqvpn_server_cfg_t *cfg)
 
     /* Control API (optional) */
     if (cfg->control_port > 0) {
-        sp.ctrl = ctrl_socket_create(sp.eb, cfg->control_addr,
-                                     cfg->control_port, sp.server);
-        if (!sp.ctrl)
-            LOG_WRN("control API setup failed — continuing without it");
+        sp.ctrl =
+            ctrl_socket_create(sp.eb, cfg->control_addr, cfg->control_port, sp.server);
+        if (!sp.ctrl) LOG_WRN("control API setup failed — continuing without it");
     }
 
     LOG_INF("mqvpn server ready — listening on %s:%d, subnet %s",

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -15,59 +15,62 @@
 
 /* ── Test infrastructure ── */
 
-static int g_tests_run    = 0;
+static int g_tests_run = 0;
 static int g_tests_passed = 0;
 
-#define TEST(name) \
+#define TEST(name)                 \
     static void test_##name(void); \
-    static void run_##name(void) { \
-        g_tests_run++; \
+    static void run_##name(void)   \
+    {                              \
+        g_tests_run++;             \
         printf("  %-50s ", #name); \
-        test_##name(); \
-        g_tests_passed++; \
-        printf("PASS\n"); \
-    } \
+        test_##name();             \
+        g_tests_passed++;          \
+        printf("PASS\n");          \
+    }                              \
     static void test_##name(void)
 
-#define ASSERT_EQ(a, b) do { \
-    if ((a) != (b)) { \
-        printf("FAIL\n    %s:%d: %s == %lld, expected %lld\n", \
-               __FILE__, __LINE__, #a, (long long)(a), (long long)(b)); \
-        exit(1); \
-    } \
-} while (0)
+#define ASSERT_EQ(a, b)                                                                \
+    do {                                                                               \
+        if ((a) != (b)) {                                                              \
+            printf("FAIL\n    %s:%d: %s == %lld, expected %lld\n", __FILE__, __LINE__, \
+                   #a, (long long)(a), (long long)(b));                                \
+            exit(1);                                                                   \
+        }                                                                              \
+    } while (0)
 
-#define ASSERT_NE(a, b) do { \
-    if ((a) == (b)) { \
-        printf("FAIL\n    %s:%d: %s == %s (unexpected)\n", \
-               __FILE__, __LINE__, #a, #b); \
-        exit(1); \
-    } \
-} while (0)
+#define ASSERT_NE(a, b)                                                                \
+    do {                                                                               \
+        if ((a) == (b)) {                                                              \
+            printf("FAIL\n    %s:%d: %s == %s (unexpected)\n", __FILE__, __LINE__, #a, \
+                   #b);                                                                \
+            exit(1);                                                                   \
+        }                                                                              \
+    } while (0)
 
-#define ASSERT_NULL(a) do { \
-    if ((a) != NULL) { \
-        printf("FAIL\n    %s:%d: %s is not NULL\n", \
-               __FILE__, __LINE__, #a); \
-        exit(1); \
-    } \
-} while (0)
+#define ASSERT_NULL(a)                                                           \
+    do {                                                                         \
+        if ((a) != NULL) {                                                       \
+            printf("FAIL\n    %s:%d: %s is not NULL\n", __FILE__, __LINE__, #a); \
+            exit(1);                                                             \
+        }                                                                        \
+    } while (0)
 
-#define ASSERT_NOT_NULL(a) do { \
-    if ((a) == NULL) { \
-        printf("FAIL\n    %s:%d: %s is NULL\n", \
-               __FILE__, __LINE__, #a); \
-        exit(1); \
-    } \
-} while (0)
+#define ASSERT_NOT_NULL(a)                                                   \
+    do {                                                                     \
+        if ((a) == NULL) {                                                   \
+            printf("FAIL\n    %s:%d: %s is NULL\n", __FILE__, __LINE__, #a); \
+            exit(1);                                                         \
+        }                                                                    \
+    } while (0)
 
-#define ASSERT_STR_EQ(a, b) do { \
-    if (strcmp((a), (b)) != 0) { \
-        printf("FAIL\n    %s:%d: \"%s\" != \"%s\"\n", \
-               __FILE__, __LINE__, (a), (b)); \
-        exit(1); \
-    } \
-} while (0)
+#define ASSERT_STR_EQ(a, b)                                                              \
+    do {                                                                                 \
+        if (strcmp((a), (b)) != 0) {                                                     \
+            printf("FAIL\n    %s:%d: \"%s\" != \"%s\"\n", __FILE__, __LINE__, (a), (b)); \
+            exit(1);                                                                     \
+        }                                                                                \
+    } while (0)
 
 /* ── Config tests ── */
 
@@ -145,26 +148,25 @@ TEST(config_add_user_max_capacity)
 
 TEST(config_load_json)
 {
-    const char *json =
-        "{"
-        "\"server_host\":\"vpn.example.com\","
-        "\"server_port\":8443,"
-        "\"auth_key\":\"legacy-key\","
-        "\"insecure\":true,"
-        "\"multipath\":false,"
-        "\"reconnect_enable\":false,"
-        "\"reconnect_interval_sec\":11,"
-        "\"killswitch_hint\":true,"
-        "\"listen_addr\":\"0.0.0.0\","
-        "\"listen_port\":443,"
-        "\"subnet\":\"10.5.0.0/24\","
-        "\"subnet6\":\"fd00::/112\","
-        "\"tls_cert\":\"/tmp/cert.pem\","
-        "\"tls_key\":\"/tmp/key.pem\","
-        "\"max_clients\":99,"
-        "\"paths\":[\"eth0\",\"wlan0\"],"
-        "\"users\":[{\"name\":\"alice\",\"key\":\"a1\"},\"bob:b1\"]"
-        "}";
+    const char *json = "{"
+                       "\"server_host\":\"vpn.example.com\","
+                       "\"server_port\":8443,"
+                       "\"auth_key\":\"legacy-key\","
+                       "\"insecure\":true,"
+                       "\"multipath\":false,"
+                       "\"reconnect_enable\":false,"
+                       "\"reconnect_interval_sec\":11,"
+                       "\"killswitch_hint\":true,"
+                       "\"listen_addr\":\"0.0.0.0\","
+                       "\"listen_port\":443,"
+                       "\"subnet\":\"10.5.0.0/24\","
+                       "\"subnet6\":\"fd00::/112\","
+                       "\"tls_cert\":\"/tmp/cert.pem\","
+                       "\"tls_key\":\"/tmp/key.pem\","
+                       "\"max_clients\":99,"
+                       "\"paths\":[\"eth0\",\"wlan0\"],"
+                       "\"users\":[{\"name\":\"alice\",\"key\":\"a1\"},\"bob:b1\"]"
+                       "}";
 
     mqvpn_config_t *cfg = mqvpn_config_new();
     ASSERT_EQ(mqvpn_config_load_json(cfg, json), MQVPN_OK);
@@ -195,10 +197,9 @@ TEST(config_load_json)
 
 TEST(config_load_json_duplicate_users_last_wins)
 {
-    const char *json =
-        "{"
-        "\"users\":[\"alice:old\", {\"name\":\"alice\",\"key\":\"new\"}]"
-        "}";
+    const char *json = "{"
+                       "\"users\":[\"alice:old\", {\"name\":\"alice\",\"key\":\"new\"}]"
+                       "}";
 
     mqvpn_config_t *cfg = mqvpn_config_new();
     ASSERT_EQ(mqvpn_config_load_json(cfg, json), MQVPN_OK);
@@ -210,10 +211,9 @@ TEST(config_load_json_duplicate_users_last_wins)
 
 TEST(config_load_json_invalid_users)
 {
-    const char *json =
-        "{"
-        "\"users\":[{\"name\":\"alice\"}]"
-        "}";
+    const char *json = "{"
+                       "\"users\":[{\"name\":\"alice\"}]"
+                       "}";
 
     mqvpn_config_t *cfg = mqvpn_config_new();
     ASSERT_EQ(mqvpn_config_load_json(cfg, json), MQVPN_ERR_INVALID_ARG);
@@ -326,6 +326,7 @@ TEST(error_string)
     ASSERT_STR_EQ(mqvpn_error_string(MQVPN_ERR_ENGINE), "engine error");
     ASSERT_STR_EQ(mqvpn_error_string(MQVPN_ERR_AGAIN), "back-pressure");
     ASSERT_STR_EQ(mqvpn_error_string(MQVPN_ERR_ABI_MISMATCH), "ABI mismatch");
+    ASSERT_STR_EQ(mqvpn_error_string(MQVPN_ERR_INVALID_STATE), "invalid state");
     /* Unknown error code */
     ASSERT_NOT_NULL(mqvpn_error_string((mqvpn_error_t)-99));
 }
@@ -348,9 +349,22 @@ static int g_state_change_count = 0;
 static mqvpn_client_state_t g_last_old_state;
 static mqvpn_client_state_t g_last_new_state;
 
-static void dummy_tun_output(const uint8_t *p, size_t l, void *u) { (void)p; (void)l; (void)u; }
-static void dummy_config_ready(const mqvpn_tunnel_info_t *i, void *u) { (void)i; (void)u; }
-static void mock_state_changed(mqvpn_client_state_t old_s, mqvpn_client_state_t new_s, void *u) {
+static void
+dummy_tun_output(const uint8_t *p, size_t l, void *u)
+{
+    (void)p;
+    (void)l;
+    (void)u;
+}
+static void
+dummy_config_ready(const mqvpn_tunnel_info_t *i, void *u)
+{
+    (void)i;
+    (void)u;
+}
+static void
+mock_state_changed(mqvpn_client_state_t old_s, mqvpn_client_state_t new_s, void *u)
+{
     (void)u;
     g_state_change_count++;
     g_last_old_state = old_s;
@@ -358,7 +372,8 @@ static void mock_state_changed(mqvpn_client_state_t old_s, mqvpn_client_state_t 
 }
 
 /* Helper: create a valid client for lifecycle tests */
-static mqvpn_client_t *make_test_client(void)
+static mqvpn_client_t *
+make_test_client(void)
 {
     mqvpn_config_t *cfg = mqvpn_config_new();
     mqvpn_config_set_server(cfg, "1.2.3.4", 443);
@@ -415,7 +430,7 @@ TEST(client_new_abi_mismatch)
     mqvpn_client_callbacks_t cbs = MQVPN_CLIENT_CALLBACKS_INIT;
     cbs.tun_output = dummy_tun_output;
     cbs.tunnel_config_ready = dummy_config_ready;
-    cbs.abi_version = 99;  /* wrong version */
+    cbs.abi_version = 99; /* wrong version */
 
     ASSERT_NULL(mqvpn_client_new(cfg, &cbs, NULL));
 
@@ -701,21 +716,45 @@ TEST(generate_key)
     ASSERT_EQ(mqvpn_generate_key(NULL, 64), MQVPN_ERR_INVALID_ARG);
 }
 
+/* ── Path reactivation preconditions ── */
+
+TEST(reactivate_path_null_client)
+{
+    ASSERT_EQ(mqvpn_client_reactivate_path(NULL, 1), MQVPN_ERR_INVALID_ARG);
+}
+
+TEST(reactivate_path_not_established)
+{
+    mqvpn_client_t *c = make_test_client();
+    /* Client is in IDLE state — reactivate should fail */
+    ASSERT_EQ(mqvpn_client_get_state(c), MQVPN_STATE_IDLE);
+    ASSERT_EQ(mqvpn_client_reactivate_path(c, 1), MQVPN_ERR_INVALID_STATE);
+
+    /* Also fails with a real path handle — state check comes first */
+    mqvpn_path_handle_t h = mqvpn_client_add_path_fd(c, 42, NULL);
+    ASSERT_NE(h, (mqvpn_path_handle_t)-1);
+    ASSERT_EQ(mqvpn_client_reactivate_path(c, h), MQVPN_ERR_INVALID_STATE);
+
+    /* Unknown handle 999 also fails with INVALID_STATE (not ESTABLISHED) */
+    ASSERT_EQ(mqvpn_client_reactivate_path(c, 999), MQVPN_ERR_INVALID_STATE);
+
+    mqvpn_client_destroy(c);
+}
+
 /* ── Server client info ── */
 
 TEST(server_get_client_info_null_safety)
 {
     mqvpn_client_info_t info[4];
     int n = 0;
-    ASSERT_EQ(mqvpn_server_get_client_info(NULL, info, 4, &n),
-              MQVPN_ERR_INVALID_ARG);
-    ASSERT_EQ(mqvpn_server_get_client_info(NULL, NULL, 4, &n),
-              MQVPN_ERR_INVALID_ARG);
+    ASSERT_EQ(mqvpn_server_get_client_info(NULL, info, 4, &n), MQVPN_ERR_INVALID_ARG);
+    ASSERT_EQ(mqvpn_server_get_client_info(NULL, NULL, 4, &n), MQVPN_ERR_INVALID_ARG);
 }
 
 /* ── Main ── */
 
-int main(void)
+int
+main(void)
 {
     printf("test_api:\n");
 
@@ -782,6 +821,10 @@ int main(void)
     /* I/O feed tests */
     run_client_on_tun_packet_null();
     run_client_on_socket_recv_null();
+
+    /* Path reactivation tests */
+    run_reactivate_path_null_client();
+    run_reactivate_path_not_established();
 
     /* Server info tests */
     run_server_get_client_info_null_safety();


### PR DESCRIPTION
Fix #32 
Path re-creation logic was lost duringlibmqvpn refactoring. When xquic detects path failure, the path was permanently CLOSED with no mechanism to re-create it. Post-recover throughput stayed at surviving-path-only levels indefinitely.

Two-layer recovery architecture:
- Library layer: tick()-based retry timer with exponential backoff (5s→60s, max 6 consecutive failures). Works on all platforms. DEGRADED state with automatic re-creation attempts.
- Platform layer: Linux netlink monitoring (RTM_NEWLINK + RTM_NEWADDR) as accelerator. Detects link recovery faster than library timer. Can also recover CLOSED paths (retries exhausted).

New API: mqvpn_client_reactivate_path() for platform-triggered recovery.
New error: MQVPN_ERR_INVALID_STATE.
New state: MQVPN_PATH_DEGRADED (transport failed, auto-retry pending).