### PR TITLE
chore(submodule): bump xquic to mqvpn-main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "third_party/xquic"]
 	path = third_party/xquic
 	url = https://github.com/mp0rta/xquic.git
-	branch = feature/masque
+	branch = mqvpn-main


### PR DESCRIPTION
Pulls in upstream alibaba/xquic catch-up via xquic mqvpn-dev:
- FEC scheme: pkt_type fix for recovered packets (xqc_fec_scheme.c)
- backup_fec scheduler: STANDBY path fec_rep_path_id update fix
- BBR1 log format fix (uint32 -> uint64 specifier)
- GCC 13 stringop-truncation warning cleanups

Excluded via revert in fork (xquic 48b7fc3): upstream PR #555 (concurrent streams limit rework, 64b8df3) — bisected as breaking MASQUE H3 DATAGRAM delivery (server_session_quic_loopback regression). Tracked locally in the fork as feat/revert-pr555 → mqvpn-dev; upstream report deferred.