### PR TITLE
ci(release): suppress noisy auto-generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,9 +137,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
+          # Body intentionally left empty — auto-generated notes are too noisy
+          # (auto-sync upstream PRs, perf bench commits, etc. clutter the changelog).
+          # Edit release notes manually after publish via GitHub UI or:
+          #   gh release edit "$GITHUB_REF_NAME" --notes "..."
           gh release create "$GITHUB_REF_NAME" \
             --title "mqvpn v${VERSION}" \
-            --generate-notes \
+            --notes "" \
             artifacts/mqvpn_*.tar.gz \
             artifacts/mqvpn_*.deb \
             artifacts/SHA256SUMS \


### PR DESCRIPTION
Auto-generated changelog includes every merged PR (auto-sync upstream, perf bench updates, CI tweaks) which clutters notification channels.
Replace --generate-notes with --notes "" so release body starts empty. 