### PR TITLE
fix no-op backup_fec scheduler and report of fec test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,12 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 option(XQUIC_BUILD_DIR "Path to pre-built xquic build directory" "")
 option(ENABLE_SANITIZERS "Enable ASan + UBSan" OFF)
 option(ENABLE_MSAN "Enable MemorySanitizer" OFF)
+option(MQVPN_DEBUG_QOS_OVERRIDE
+       "Enable MQVPN_DGRAM_QOS_OVERRIDE env var for FEC ablation testing — debug only"
+       OFF)
+if(MQVPN_DEBUG_QOS_OVERRIDE)
+    add_compile_definitions(MQVPN_DEBUG_QOS_OVERRIDE)
+endif()
 
 if(ENABLE_SANITIZERS)
     add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer -Werror)

--- a/src/mqvpn_client.c
+++ b/src/mqvpn_client.c
@@ -1668,7 +1668,7 @@ mqvpn_client_on_tun_packet(mqvpn_client_t *c, const uint8_t *pkt, size_t len)
     uint32_t fh = flow_hash_pkt(pkt, (int)len);
     xqc_conn_set_dgram_flow_hash(xqc_h3_conn_get_xqc_conn(conn->h3_conn), fh);
     xret = xqc_h3_ext_datagram_send(conn->h3_conn, frame_buf, frame_written, &dgram_id,
-                                    XQC_DATA_QOS_HIGH);
+                                    mqvpn_dgram_qos_level(c->config.scheduler));
 
     if (xret == -XQC_EAGAIN) {
         c->backpressure = 1;

--- a/src/mqvpn_scheduler.h
+++ b/src/mqvpn_scheduler.h
@@ -8,6 +8,8 @@
 
 #include "libmqvpn.h"
 #include <xquic/xquic.h> /* brings in xqc_configure.h with XQC_ENABLE_* defines */
+#include <stdlib.h>      /* getenv */
+#include <string.h>      /* strcmp */
 
 /* ===========================================================================
  * MQVPN_SCHED_BACKUP_FEC tuning knobs (only meaningful on FEC-enabled builds)
@@ -20,7 +22,6 @@
  * Lowering CODE_RATE further has no effect until BLOCK_SIZE grows past 1/CODE_RATE.
  *
  * To experiment: change values, rebuild, re-run perf-weekly bench.
- * Spec: docs/superpowers/specs/2026-04-25-backup-fec-design.md
  *
  * TODO: Task 14 (FEC-downgrade warning at ESTABLISHED) was deferred — xquic
  * has no public API to query negotiated FEC status post-handshake. Revisit
@@ -35,5 +36,36 @@
 /* Apply scheduler-specific xquic conn settings (callback + FEC params).
  * Used by both client (mqvpn_client.c) and server (mqvpn_server.c). */
 void mqvpn_apply_scheduler(xqc_conn_settings_t *cs, mqvpn_scheduler_t sched);
+
+/* Map scheduler choice → DATAGRAM send-time QoS level.
+ *
+ * xquic only enables FEC encoding for DATAGRAMs when qos > XQC_DATA_QOS_HIGH
+ * (third_party/xquic/src/transport/xqc_packet_out.c:1317-1326). On FEC-enabled
+ * builds with MQVPN_SCHED_BACKUP_FEC selected, return NORMAL so repair packets
+ * actually get generated. All other cases keep HIGH (current default).
+ */
+static inline xqc_data_qos_level_t
+mqvpn_dgram_qos_level(mqvpn_scheduler_t s)
+{
+#ifdef MQVPN_DEBUG_QOS_OVERRIDE
+    {
+        const char *override = getenv("MQVPN_DGRAM_QOS_OVERRIDE");
+        if (override) {
+            if (strcmp(override, "high") == 0) return XQC_DATA_QOS_HIGH;
+            if (strcmp(override, "medium") == 0) return XQC_DATA_QOS_MEDIUM;
+            if (strcmp(override, "normal") == 0) return XQC_DATA_QOS_NORMAL;
+            if (strcmp(override, "low") == 0) return XQC_DATA_QOS_LOW;
+            if (strcmp(override, "lowest") == 0) return XQC_DATA_QOS_LOWEST;
+        }
+    }
+#endif
+#if defined(XQC_ENABLE_FEC) && defined(XQC_ENABLE_XOR)
+    if (s == MQVPN_SCHED_BACKUP_FEC) {
+        return XQC_DATA_QOS_NORMAL;
+    }
+#endif
+    (void)s;
+    return XQC_DATA_QOS_HIGH;
+}
 
 #endif /* MQVPN_SCHEDULER_H */

--- a/src/mqvpn_server.c
+++ b/src/mqvpn_server.c
@@ -233,10 +233,12 @@ svr_log_conn_stats(mqvpn_server_t *s, const char *tag, const xqc_cid_t *cid)
     LOG_I(s,
           "%s: send=%u recv=%u lost=%u lost_dgram=%u srtt=%.2fms "
           "min_rtt=%.2fms inflight=%" PRIu64 " app_bytes=%" PRIu64
-          " standby_bytes=%" PRIu64 " mp_state=%d",
+          " standby_bytes=%" PRIu64 " mp_state=%d "
+          "fec_enable=%u fec_send=%u fec_recover=%u",
           tag, st.send_count, st.recv_count, st.lost_count, st.lost_dgram_count,
           (double)st.srtt / 1000.0, (double)st.min_rtt / 1000.0, st.inflight_bytes,
-          st.total_app_bytes, st.standby_path_app_bytes, st.mp_state);
+          st.total_app_bytes, st.standby_path_app_bytes, st.mp_state, st.enable_fec,
+          st.send_fec_cnt, st.fec_recover_pkt_cnt);
 }
 
 /* ─── ICMP PTB rate limiter ─── */
@@ -1424,7 +1426,7 @@ mqvpn_server_on_tun_packet(mqvpn_server_t *s, const uint8_t *pkt, size_t len)
     uint32_t fh = flow_hash_pkt(pkt, (int)len);
     xqc_conn_set_dgram_flow_hash(xqc_h3_conn_get_xqc_conn(target->h3_conn), fh);
     xret = xqc_h3_ext_datagram_send(target->h3_conn, frame_buf, frame_written, &dgram_id,
-                                    XQC_DATA_QOS_HIGH);
+                                    mqvpn_dgram_qos_level(s->config.scheduler));
 
     if (xret == -XQC_EAGAIN) {
         s->tun_paused = 1;

--- a/tests/perf_fec_qos_ablation.sh
+++ b/tests/perf_fec_qos_ablation.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# perf_fec_qos_ablation.sh — FEC QoS ablation matrix.
+#
+# Compares HIGH (FEC off) vs NORMAL (FEC on) DATAGRAM QoS across 4 netem
+# profiles and writes results as CSV + a markdown summary.
+#
+# REQUIRES:
+#   - root (netem on netns)
+#   - build with -DMQVPN_DEBUG_QOS_OVERRIDE=ON -DXQC_ENABLE_FEC=ON -DXQC_ENABLE_XOR=ON
+#   - iperf3
+#   - netem (sch_netem kernel module; modprobe sch_netem if missing)
+#
+# Run:
+#   sudo bash tests/perf_fec_qos_ablation.sh [path/to/mqvpn]
+#
+# Output:
+#   - CSV to stdout
+#   - docs/superpowers/2026-04-27-pr1-fec-qos-results.md (markdown table)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/../benchmarks/bench_env_setup.sh"
+
+# Probe netem availability — fail fast if the kernel module is missing,
+# otherwise the loss/delay cells will silently behave like no_loss.
+if ! tc qdisc add dev lo root netem loss 0% 2>/dev/null; then
+    echo "ERROR: 'tc qdisc … netem' not available. Load sch_netem (modprobe sch_netem) or check tc/iproute2 install." >&2
+    exit 2
+fi
+tc qdisc del dev lo root 2>/dev/null || true
+
+MQVPN="${1:-${MQVPN}}"
+LOG_DIR="$(mktemp -d)"
+ALL_WORK_DIRS=()
+RESULTS="${SCRIPT_DIR}/../docs/superpowers/2026-04-27-pr1-fec-qos-results.md"
+trap 'bench_cleanup; for d in "${ALL_WORK_DIRS[@]}"; do rm -rf "$d"; done; rm -rf "$LOG_DIR"' EXIT
+
+QOS_LEVELS=("high" "normal")
+declare -A NETEM_PROFILES=(
+    [no_loss]=""
+    [loss_5]="loss 5%"
+    [loss_5_burst]="loss 5% 25%"
+    [ntn_like]="loss 1% delay 50ms 10ms"
+)
+
+run_one_cell() {
+    local qos="$1"
+    local profile="$2"
+    local netem="$3"
+
+    bench_setup_netns
+    if [[ -n "$netem" ]]; then
+        ip netns exec "$NS_CLIENT" tc qdisc add dev veth-a0 root netem $netem || true
+    fi
+
+    BENCH_SCHEDULER="backup_fec"
+    export MQVPN_DGRAM_QOS_OVERRIDE="$qos"
+    local server_log="${LOG_DIR}/${qos}_${profile}_server.log"
+    local client_log="${LOG_DIR}/${qos}_${profile}_client.log"
+
+    # Generate PSK and TLS cert for this cell (matches bench_start_vpn_server
+    # flow which always regenerates into a fresh _BENCH_WORK_DIR).
+    _BENCH_WORK_DIR="$(mktemp -d)"
+    ALL_WORK_DIRS+=("$_BENCH_WORK_DIR")
+    _BENCH_PSK=$("$MQVPN" --genkey 2>/dev/null)
+    openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+        -keyout "${_BENCH_WORK_DIR}/server.key" -out "${_BENCH_WORK_DIR}/server.crt" \
+        -days 365 -nodes -subj "/CN=mqvpn-bench" 2>/dev/null
+
+    # Start server inside the server netns.
+    # Flags deliberately mirror bench_start_vpn_server (bench_env_setup.sh L143-151).
+    ip netns exec "$NS_SERVER" "$MQVPN" \
+        --mode server \
+        --listen "0.0.0.0:${VPN_LISTEN_PORT}" \
+        --subnet 10.0.0.0/24 \
+        --cert "${_BENCH_WORK_DIR}/server.crt" \
+        --key  "${_BENCH_WORK_DIR}/server.key" \
+        --auth-key "$_BENCH_PSK" \
+        --scheduler "$BENCH_SCHEDULER" \
+        --log-level "$BENCH_LOG_LEVEL" \
+        >"$server_log" 2>&1 &
+    _BENCH_SERVER_PID=$!
+    sleep 1
+
+    bench_start_vpn_client "--path veth-a0 --path veth-b0" "$client_log"
+    sleep 2
+
+    local sent=1000
+    local recv
+    recv=$(ip netns exec "$NS_CLIENT" \
+        timeout 5 ping -c "$sent" -i 0.001 "$TUNNEL_SERVER_IP" 2>/dev/null \
+        | grep -oE '[0-9]+ received' | awk '{print $1}' || true)
+    recv=${recv:-0}
+    local loss_pct
+    loss_pct=$(awk -v r="$recv" -v s="$sent" 'BEGIN{ printf "%.2f", (s-r)*100.0/s }')
+
+    local iperf_pidfile="${LOG_DIR}/iperf3.pid"
+    ip netns exec "$NS_SERVER" iperf3 -s -D --pidfile "$iperf_pidfile" >/dev/null 2>&1 || true
+    sleep 1
+    if [[ ! -f "$iperf_pidfile" ]] || ! kill -0 "$(cat "$iperf_pidfile" 2>/dev/null)" 2>/dev/null; then
+        echo "  WARN: iperf3 server failed to start in cell ${qos}/${profile}" >&2
+    fi
+    local tput_mbps
+    tput_mbps=$(ip netns exec "$NS_CLIENT" \
+        iperf3 -c "$TUNNEL_SERVER_IP" -t 5 -J 2>/dev/null \
+        | grep -oE '"bits_per_second":\s*[0-9.]+' | tail -1 \
+        | grep -oE '[0-9.]+' | awk '{ printf "%.2f", $1/1000000 }' || true)
+    tput_mbps=${tput_mbps:-0}
+    kill "$(cat "$iperf_pidfile" 2>/dev/null)" 2>/dev/null || true
+
+    # Trigger graceful close so the server flushes svr_log_conn_stats
+    if [[ -n "$_BENCH_CLIENT_PID" ]]; then
+        kill -TERM "$_BENCH_CLIENT_PID" 2>/dev/null || true
+        wait "$_BENCH_CLIENT_PID" 2>/dev/null || true
+    fi
+    sleep 2
+
+    local fec_send fec_recover
+    fec_send=$(grep -oE 'fec_send=[0-9]+' "$server_log" | tail -1 | cut -d= -f2 || true)
+    fec_send=${fec_send:-0}
+    fec_recover=$(grep -oE 'fec_recover=[0-9]+' "$server_log" | tail -1 | cut -d= -f2 || true)
+    fec_recover=${fec_recover:-0}
+
+    local cpu_user cpu_sys
+    read -r cpu_user cpu_sys < <(top -bn1 | awk '/^%Cpu/ { print $2, $4; exit }')
+    cpu_user=${cpu_user:-0}
+    cpu_sys=${cpu_sys:-0}
+
+    echo "${qos},${profile},${loss_pct},${tput_mbps},${fec_send:-0},${fec_recover:-0},${cpu_user:-0},${cpu_sys:-0}"
+
+    bench_cleanup
+    unset MQVPN_DGRAM_QOS_OVERRIDE
+}
+
+echo "qos,netem,inner_udp_loss_pct,inner_tcp_throughput_mbps,fec_send,fec_recover,cpu_user_pct,cpu_sys_pct"
+for qos in "${QOS_LEVELS[@]}"; do
+    for profile in "${!NETEM_PROFILES[@]}"; do
+        run_one_cell "$qos" "$profile" "${NETEM_PROFILES[$profile]}"
+    done
+done | tee "${LOG_DIR}/results.csv"
+
+mkdir -p "$(dirname "$RESULTS")"
+{
+    echo "# PR1 FEC QoS ablation results"
+    echo ""
+    echo "**Run date:** $(date -u +%Y-%m-%d)"
+    echo "**Build:** \`-DMQVPN_DEBUG_QOS_OVERRIDE=ON -DXQC_ENABLE_FEC=ON -DXQC_ENABLE_XOR=ON\`"
+    echo ""
+    echo "| QoS | netem | UDP loss % | TCP Mbps | fec_send | fec_recover | CPU u/s |"
+    echo "|---|---|---|---|---|---|---|"
+    # Filter out helper-stdout noise that the outer `tee` captured alongside
+    # the per-cell echo lines. Only rows whose qos column matches the matrix
+    # values and that have all 8 fields are real data.
+    awk -F, 'NF==8 && $1 ~ /^(high|normal)$/ { printf "| %s | %s | %s | %s | %s | %s | %s/%s |\n", $1,$2,$3,$4,$5,$6,$7,$8 }' \
+        "${LOG_DIR}/results.csv"
+    echo ""
+    echo "## Expected observations"
+    echo ""
+    echo "- \`loss_5_burst\` row: \`UDP loss %\` for \`normal\` < \`high\` — confirms FEC recovery."
+    echo "- \`no_loss\` row: \`TCP Mbps\` for \`normal\` ≈ \`high\` — no priority side-effect regression."
+} > "$RESULTS"
+
+echo ""
+echo "Results written to $RESULTS"

--- a/tests/test_e2e_backup_fec.sh
+++ b/tests/test_e2e_backup_fec.sh
@@ -96,8 +96,89 @@ test_compat_client_fec_server_wlb() {
     return 0
 }
 
+# --- Test 3: backup_fec actually emits repair packets ---
+
+test_backup_fec_emits_repairs() {
+    local server_log="${LOG_DIR}/repair_server.log"
+    bench_cleanup
+    bench_setup_netns
+    BENCH_SCHEDULER="backup_fec"
+
+    # bench_start_vpn_server takes no log-path argument; it redirects to the
+    # shell's stdout.  We call it to generate the PSK and TLS cert/key in
+    # _BENCH_WORK_DIR, then kill the server it started and restart it with
+    # explicit log capture so we can grep fec_send= afterwards.
+    bench_start_vpn_server
+
+    # Kill the server spawned by the helper and re-launch with log capture.
+    kill "$_BENCH_SERVER_PID" 2>/dev/null || true
+    wait "$_BENCH_SERVER_PID" 2>/dev/null || true
+
+    ip netns exec "$NS_SERVER" "$MQVPN" \
+        --mode server \
+        --listen "0.0.0.0:${VPN_LISTEN_PORT}" \
+        --subnet 10.0.0.0/24 \
+        --cert "${_BENCH_WORK_DIR}/server.crt" \
+        --key "${_BENCH_WORK_DIR}/server.key" \
+        --auth-key "$_BENCH_PSK" \
+        --scheduler "$BENCH_SCHEDULER" \
+        --log-level "$BENCH_LOG_LEVEL" >"$server_log" 2>&1 &
+    _BENCH_SERVER_PID=$!
+    sleep 2
+
+    if ! kill -0 "$_BENCH_SERVER_PID" 2>/dev/null; then
+        echo "  FAIL: restarted server process died"
+        return 1
+    fi
+
+    bench_start_vpn_client "--path veth-a0 --path veth-b0" "${LOG_DIR}/repair_client.log"
+
+    sleep 2
+
+    # Generate ~5s of UDP traffic through the tunnel to fill at least one FEC block
+    if command -v iperf3 >/dev/null; then
+        ip netns exec "$NS_SERVER" iperf3 -s -D --pidfile /tmp/iperf3-fec-repair.pid >/dev/null 2>&1 || true
+        sleep 1
+        ip netns exec "$NS_CLIENT" iperf3 -c "$TUNNEL_SERVER_IP" -u -b 50M -t 5 >/dev/null 2>&1 || true
+        kill "$(cat /tmp/iperf3-fec-repair.pid 2>/dev/null)" 2>/dev/null || true
+    else
+        # Fallback: many pings to drive enough packets
+        ip netns exec "$NS_CLIENT" ping -c 200 -i 0.02 "$TUNNEL_SERVER_IP" >/dev/null 2>&1 || true
+    fi
+
+    # Trigger graceful close on the client so the server flushes conn stats
+    # (svr_log_conn_stats is only called from cb_h3_conn_close or the loss
+    # checkpoint; see mqvpn_server.c:454 / 1032).
+    if [[ -n "$_BENCH_CLIENT_PID" ]]; then
+        kill -TERM "$_BENCH_CLIENT_PID" 2>/dev/null || true
+        # Give xquic time to send CONNECTION_CLOSE and the server to log stats
+        wait "$_BENCH_CLIENT_PID" 2>/dev/null || true
+    fi
+
+    sleep 2  # let the server's cb_h3_conn_close flush
+
+    local fec_send
+    fec_send=$(grep -oE 'fec_send=[0-9]+' "$server_log" | tail -1 | cut -d= -f2)
+    if [[ -z "$fec_send" ]]; then
+        echo "  FAIL: server log never emitted fec_send= line"
+        echo "  --- last 20 lines of server log ---"
+        tail -20 "$server_log"
+        return 1
+    fi
+    if (( fec_send == 0 )); then
+        echo "  FAIL: fec_send=0 — backup_fec did not emit any repair packets"
+        echo "  --- relevant log lines ---"
+        grep -E "fec_(send|recover|enable)" "$server_log" | tail -10
+        return 1
+    fi
+
+    echo "  OK: fec_send=$fec_send (FEC repair packets observed)"
+    return 0
+}
+
 run_test "symmetric backup_fec" test_symmetric_backup_fec
 run_test "compat: client=backup_fec, server=wlb" test_compat_client_fec_server_wlb
+run_test "backup_fec emits repair packets" test_backup_fec_emits_repairs
 
 echo ""
 echo "================================================="

--- a/tests/test_scheduler.c
+++ b/tests/test_scheduler.c
@@ -127,6 +127,24 @@ test_minrtt_zero_paths_no_warn(void)
     return 0;
 }
 
+#if defined(XQC_ENABLE_FEC) && defined(XQC_ENABLE_XOR)
+static int
+test_dgram_qos_for_backup_fec(void)
+{
+    ASSERT_EQ(mqvpn_dgram_qos_level(MQVPN_SCHED_BACKUP_FEC), XQC_DATA_QOS_NORMAL);
+    return 0;
+}
+#endif
+
+static int
+test_dgram_qos_for_other_schedulers(void)
+{
+    ASSERT_EQ(mqvpn_dgram_qos_level(MQVPN_SCHED_MINRTT), XQC_DATA_QOS_HIGH);
+    ASSERT_EQ(mqvpn_dgram_qos_level(MQVPN_SCHED_WLB), XQC_DATA_QOS_HIGH);
+    ASSERT_EQ(mqvpn_dgram_qos_level((mqvpn_scheduler_t)999), XQC_DATA_QOS_HIGH);
+    return 0;
+}
+
 int
 main(void)
 {
@@ -141,6 +159,10 @@ main(void)
     failed += test_unknown_falls_back_to_minrtt();
     failed += test_backup_fec_single_path_needs_warn();
     failed += test_backup_fec_two_paths_no_warn();
+#if defined(XQC_ENABLE_FEC) && defined(XQC_ENABLE_XOR)
+    failed += test_dgram_qos_for_backup_fec();
+#endif
+    failed += test_dgram_qos_for_other_schedulers();
     failed += test_wlb_single_path_no_warn();
     failed += test_minrtt_zero_paths_no_warn();
     if (failed) {


### PR DESCRIPTION
 ## Summary

  `--scheduler backup_fec` was effectively a no-op for DATAGRAM packets. xquic's FEC
  encode gate (`xqc_packet_out.c:1317-1326`) requires `qos_level > XQC_DATA_QOS_HIGH`, but
   mqvpn was sending all DATAGRAMs at `XQC_DATA_QOS_HIGH`, so `XQC_POF_USE_FEC` was never
  set, no repair packets were generated, and the `backup_fec` scheduler had no FEC traffic
   to route to STANDBY paths.

  This PR introduces `mqvpn_dgram_qos_level()`, which lowers the QoS to
  `XQC_DATA_QOS_NORMAL` only when `MQVPN_SCHED_BACKUP_FEC` is selected. Every other
  scheduler is bit-identical to before.

  ## Verification

  - 9/9 ctests pass on the default build
  - `sudo bash tests/test_e2e_backup_fec.sh` — 3/3 sub-tests pass; `fec_send=6` confirms
  repair packets are emitted end-to-end
  - `sudo bash tests/perf_fec_qos_ablation.sh` under 5% iid loss (separate run from the
  grid below; runs were 1 day apart in the same netns harness):
    - QoS=HIGH (pre-PR baseline) inner TCP throughput: **15.52 Mbps**
    - QoS=NORMAL (this PR)        inner TCP throughput: **72.32 Mbps** (≈ 4.7×)

  ## Default FEC parameters: investigation and decision

  Checked whether the inherited defaults (`MQVPN_FEC_SCHEME=XOR`, `BLOCK_SIZE=3`,
  `CODE_RATE=0.1f` — copied from xquic's reference test client) had ever been benchmarked
  against alternatives. To answer, I ran a local grid ablation over `(scheme, K, rate)`:
  XOR(3,1), RS(3,1), RS(8,2), RS(8,4), RS(16,4) × 4 netem profiles. `R = max(1, K × rate)`
   is xquic's per-block repair count.

  ### Results

  #### `no_loss` — clean link, overhead measurement

  | tag | scheme | K | R | TCP Mbps | fec_send | fec_recover |
  |---|---|---|---|---|---|---|
  | **xor_3_1** (baseline) | XOR | 3 | 1 | **85.68** | 8269 | 0 |
  | rs_3_1 | RS | 3 | 1 | 72.68 | 7258 | 0 |
  | rs_8_2 | RS | 8 | 2 | 73.11 | 5384 | 0 |
  | rs_8_4 | RS | 8 | 4 | 62.01 | 9300 | 0 |
  | rs_16_4 | RS | 16 | 4 | 105.47\* | **0\*** | 0 |

  #### `loss_5` — 5% iid loss on one path

  | tag | scheme | K | R | TCP Mbps | fec_send | fec_recover |
  |---|---|---|---|---|---|---|
  | **xor_3_1** (baseline) | XOR | 3 | 1 | **77.36** | 7806 | 1758 |
  | rs_3_1 | RS | 3 | 1 | 70.68 | 7398 | 1694 |
  | rs_8_2 | RS | 8 | 2 | 66.24 | 5886 | 1691 |
  | rs_8_4 | RS | 8 | 4 | 61.80 | 11180 | 1580 |
  | rs_16_4 | RS | 16 | 4 | 14.89\* | **0\*** | 0 |

  #### `loss_5_burst` — 5% loss with 25% correlation

  | tag | scheme | K | R | TCP Mbps | fec_send | fec_recover |
  |---|---|---|---|---|---|---|
  | **xor_3_1** (baseline) | XOR | 3 | 1 | **82.54** | 7849 | 71 |
  | rs_3_1 | RS | 3 | 1 | 71.80 | 6915 | 68 |
  | rs_8_2 | RS | 8 | 2 | 76.25 | 5364 | 68 |
  | rs_8_4 | RS | 8 | 4 | 59.80 | 8648 | 61 |
  | rs_16_4 | RS | 16 | 4 | 103.36\* | **0\*** | 0 |

  #### `ntn_like` — 1% loss + 50ms ± 10ms delay

  | tag | scheme | K | R | TCP Mbps | fec_send | fec_recover |
  |---|---|---|---|---|---|---|
  | **xor_3_1** (baseline) | XOR | 3 | 1 | **76.65** | 7548 | 28 |
  | rs_3_1 | RS | 3 | 1 | 80.88 | 7720 | 19 |
  | rs_8_2 | RS | 8 | 2 | 73.08 | 5446 | 86 |
  | rs_8_4 | RS | 8 | 4 | 64.10 | 9444 | 35 |
  | rs_16_4 | RS | 16 | 4 | 108.91\* | **0\*** | 0 |

  \* `fec_send=0`: RS at K=16 with R=4 silently runs without producing any repair packets.
   Neither `XQC_FEC_MAX_SYMBOL_NUM_PBLOCK=48` (limit on K) nor `XQC_REPAIR_LEN=10` (limit
  on R) is exceeded, so the cause is presumably an xquic runtime check or
  scheme-negotiation behavior we haven't traced yet. The high TCP throughput in those rows
   therefore reflects a no-FEC baseline, not a working RS configuration. Inner-IP ICMP
  ping loss in `loss_5` was 5.20% in this row (vs. 0% for every row where FEC was active),
   which doubles as a positive control that the loss-measurement path itself works.

  The column labeled "UDP loss %" in the CSV is actually inner-IP **ICMP ping** loss (1000
   echo requests at 1 ms intervals through the tunnel — there is no UDP-specific test in
  this experiment). Every row reads 0% except the `rs_16_4 / loss_5` anomaly above. Where
  FEC was active, every single-packet underlay loss was absorbed by FEC before reaching
  the inner layer (QUIC DATAGRAMs are unreliable, so this is the FEC mechanism, not a QUIC
   retransmission). The ~1-second sample is too short to surface subtler differences
  between FEC configurations, so **only the TCP Mbps column is load-bearing for
  between-scheme comparison.**

  ### Open questions (out of scope here, candidates for follow-up)

  1. **rs_3_1 throughput is 9–15% lower than xor_3_1 in 3 of 4 profiles** (`no_loss`,
  `loss_5`, `loss_5_burst`) despite identical K/R parameters and very similar
  `fec_send`/`fec_recover` counts. The `ntn_like` profile inverts the trend (rs_3_1
  +5.5%), which is unexplained. The Galois-field arithmetic overhead alone doesn't account
   for the dominant pattern — xquic's RS code path itself may be less efficient than its
  XOR path.
  2. **R=2 and R=4 recover roughly the same number of packets as R=1** (rs_3_1 / rs_8_2 /
  rs_8_4 all land in 1580–1694 recoveries on `loss_5`). At 5% iid loss, blocks rarely
  contain ≥2 lost packets in K=8, so the extra recovery capacity may simply not be
  exercised — or FEC negotiation may not honor the requested R. Needs a debug-level xquic
  log inspection to confirm.
  3. **rs_16_4 reports `fec_send=0` everywhere** (asterisked rows above). See the asterisk
   footnote for the bound check. Likely an xquic runtime check or scheme-negotiation path
  that silently disables FEC for this combination.
  4. **Inner-IP ping loss measurement is too coarse to compare FEC configurations.** With
  only 1000 ICMP echos at 1 ms intervals (~1 s of traffic), FEC absorbs every
  single-packet underlay loss in active-FEC rows, so all such rows read 0%. The column is
  useful as a positive control (the rs_16_4 / loss_5 = 5.20% confirms the path is wired
  and that FEC is genuinely off in that row) but cannot rank between FEC configurations. A
   longer run, or `iperf3 -u --get-server-output` for true UDP-loss reporting, would be
  needed.

  ### Bursty loss

  In `loss_5_burst`, every scheme recovers only ~70 packets (recovery rate ≈ 1%). This is
  the structural limit of block FEC: bursts longer than R are unrecoverable. NTN-class
  handover bursts call for sliding-window RLNC etc, which has a separate design doc and is a
  few long scope task.

## result
For the time being, we will stop be providing support RS and continue with XOR.
While accelerating xquic's RS path (e.g., SIMD-accelerated Galois field computation, Cauchy RS) could potentially make `rs_8_2` surpass `xor_3_1` in absolute throughput, its effectiveness is limited by the structural limitations of block FEC (block formation delay, unrecoverable bursts > R). Applying the same engineering effort to an existing systematic / sliding window RLNC is expected to deliver lossless overhead, burst tolerance, and zero decoding cost on a clean link all at once, resulting in a high ROI.