### PR TITLE
client: rotate primary path on reconnect #46

### DIFF
--- a/src/mqvpn_client.c
+++ b/src/mqvpn_client.c
@@ -425,6 +425,41 @@ client_next_primary_idx(const mqvpn_client_t *c, int from_idx)
     return from_idx;
 }
 
+/* Test-only wrappers: expose primary-rotation internals so test_api can
+ * lock in the issue #46 + OMR-backport composite fallback semantics
+ * without driving xquic.  Hidden from libmqvpn.so's dynamic export
+ * table (not part of public ABI). */
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((visibility("hidden")))
+#endif
+int
+mqvpn_client_test_set_primary_path_idx(mqvpn_client_t *c, int idx)
+{
+    if (!c) return -1;
+    c->primary_path_idx = idx;
+    return 0;
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((visibility("hidden")))
+#endif
+int
+mqvpn_client_test_get_fd_for_path(mqvpn_client_t *c, uint64_t xqc_path_id)
+{
+    if (!c) return -1;
+    return get_fd_for_path(c, xqc_path_id);
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((visibility("hidden")))
+#endif
+int
+mqvpn_client_test_next_primary_idx(const mqvpn_client_t *c, int from_idx)
+{
+    if (!c) return -1;
+    return client_next_primary_idx(c, from_idx);
+}
+
 /* ─── ICMP PTB rate limiter ─── */
 
 static int

--- a/src/mqvpn_client.c
+++ b/src/mqvpn_client.c
@@ -162,6 +162,9 @@ struct mqvpn_client_s {
     int n_paths;
     int64_t next_path_handle;
     int multipath_ready; /* 1 after cb_ready_to_create_path */
+    /* Path index used for the QUIC handshake. Rotated on each reconnect so a
+     * dead first path doesn't trap the client forever. */
+    int primary_path_idx;
 
     /* Reconnect */
     int reconnect_attempts;
@@ -384,13 +387,42 @@ mqvpn_client_first_active_fd(const mqvpn_client_t *c)
     return idx >= 0 ? c->paths[idx].fd : -1;
 }
 
-/* Get fd for xquic path_id, falling back to the first active slot. */
+/* Get fd for xquic path_id, falling back to the (rotated) primary slot if
+ * still active, else to the first active slot.
+ *
+ * Two requirements compose here:
+ *   - The handshake fallback must use `primary_path_idx` (rotation owner)
+ *     so a dead first-configured path doesn't trap reconnect (issue #46).
+ *   - After multipath setup, if the primary was dropped mid-session we
+ *     must NOT hand back its stale fd — fall through to any active sibling
+ *     (post-OMR-backport semantics protecting against EBADF / sendto-on-
+ *     dead-iface).
+ */
 static int
 get_fd_for_path(mqvpn_client_t *c, uint64_t xqc_path_id)
 {
     path_entry_t *p = find_path_by_xqc_id(c, xqc_path_id);
     if (p) return p->fd;
+    int pidx = c->primary_path_idx;
+    if (pidx < c->n_paths && c->paths[pidx].active) return c->paths[pidx].fd;
     return mqvpn_client_first_active_fd(c);
+}
+
+/* Pick the next active path index for the next handshake attempt.
+ * Skips paths that the platform has marked inactive or the library has
+ * already closed. Returns the input index if no other candidate exists. */
+static int
+client_next_primary_idx(const mqvpn_client_t *c, int from_idx)
+{
+    if (c->n_paths <= 0) return 0;
+    int start = (from_idx + 1) % c->n_paths;
+    int i = start;
+    do {
+        const path_entry_t *p = &c->paths[i];
+        if (p->active && p->status != MQVPN_PATH_CLOSED) return i;
+        i = (i + 1) % c->n_paths;
+    } while (i != start);
+    return from_idx;
 }
 
 /* ─── ICMP PTB rate limiter ─── */
@@ -457,6 +489,9 @@ client_reset_paths_for_reconnect(mqvpn_client_t *c)
     for (int i = 0; i < c->n_paths; i++) {
         client_reset_path_runtime(&c->paths[i]);
     }
+    /* Try the next configured path next time so a dead first path
+     * (e.g. interface up but no upstream connectivity) doesn't trap us. */
+    c->primary_path_idx = client_next_primary_idx(c, c->primary_path_idx);
 }
 
 static int
@@ -533,11 +568,17 @@ cb_write_socket(const unsigned char *buf, size_t size, const struct sockaddr *pe
 {
     cli_conn_t *conn = (cli_conn_t *)conn_user_data;
     mqvpn_client_t *c = conn->client;
-    /* Pick the first still-active slot.  A naive `paths[0].fd` fallback
-     * would hand back the fd of a path that was just dropped (the
-     * platform may have already closed the descriptor or moved it onto a
-     * doomed interface). */
-    int active_idx = first_active_idx(c);
+    /* Prefer the rotated handshake primary (issue #46); fall back to any
+     * still-active slot if the primary was dropped mid-session. Without
+     * primary preference, handshake on a non-paths[0] primary would silently
+     * sendto via paths[0].fd. Without first-active fallback, a dropped
+     * primary mid-session would sendto via a dead fd / EBADF. */
+    int active_idx = -1;
+    int pidx = c->primary_path_idx;
+    if (pidx < c->n_paths && c->paths[pidx].active)
+        active_idx = pidx;
+    else
+        active_idx = first_active_idx(c);
     int fd = (active_idx >= 0) ? c->paths[active_idx].fd : -1;
     if (fd < 0) return XQC_SOCKET_ERROR;
 
@@ -912,10 +953,12 @@ cb_request_read(xqc_h3_request_t *h3_request, xqc_request_notify_flag_t flag,
             }
 
             /* Primary path is now active */
-            if (c->n_paths > 0 && c->paths[0].active) {
-                c->paths[0].status = MQVPN_PATH_ACTIVE;
+            int pidx = c->primary_path_idx;
+            if (c->n_paths > 0 && pidx < c->n_paths && c->paths[pidx].active) {
+                c->paths[pidx].status = MQVPN_PATH_ACTIVE;
                 if (c->cbs.path_event)
-                    c->cbs.path_event(c->paths[0].handle, MQVPN_PATH_ACTIVE, c->user_ctx);
+                    c->cbs.path_event(c->paths[pidx].handle, MQVPN_PATH_ACTIVE,
+                                      c->user_ctx);
             }
 
             client_set_state(c, MQVPN_STATE_TUNNEL_READY);
@@ -1127,7 +1170,9 @@ cb_ready_to_create_path(const xqc_cid_t *cid, void *conn_user_data)
     c->multipath_ready = 1;
     if (!c->config.multipath) return;
 
-    for (int i = 1; i < c->n_paths; i++) {
+    /* Start from 0 — the primary path may be at any index after rotation;
+     * the in_use check below skips whichever slot is already in use. */
+    for (int i = 0; i < c->n_paths; i++) {
         path_entry_t *p = &c->paths[i];
         if (p->in_use || !p->active) continue;
         client_activate_path(c, p, i);
@@ -1359,9 +1404,9 @@ cli_start_connection(mqvpn_client_t *c)
     if (conn->h3_conn) xqc_h3_ext_datagram_set_user_data(conn->h3_conn, conn);
 
     /* Mark primary path */
-    if (c->n_paths > 0) {
-        c->paths[0].xqc_path_id = 0;
-        c->paths[0].in_use = 1;
+    if (c->n_paths > 0 && c->primary_path_idx < c->n_paths) {
+        c->paths[c->primary_path_idx].xqc_path_id = 0;
+        c->paths[c->primary_path_idx].in_use = 1;
     }
 
     c->conn = conn; /* ownership transfer — cleanup won't free */

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -1103,6 +1103,114 @@ TEST(rollback_after_activation_failure_emits_degraded_then_closed)
     mqvpn_client_destroy(c);
 }
 
+/* ── Primary-path rotation (issue #46) + OMR write-socket fallback ──
+ *
+ * Locks in the composite semantic for the no-path_id write fallback in
+ * cb_write_socket / get_fd_for_path:
+ *   1. Prefer the rotated primary (issue #46) so a non-paths[0] primary
+ *      actually receives handshake bytes.
+ *   2. Fall back to the first active slot (OMR backport) when the primary
+ *      was dropped mid-session — never sendto via a stale fd.
+ *
+ * Without test 1, a future refactor could collapse the fallback back
+ * into `first_active_idx` alone and silently regress issue #46. Without
+ * test 2, the same refactor in the opposite direction would re-introduce
+ * the dropped-primary EBADF bug. Test 3 pins the rotation helper. */
+
+extern int mqvpn_client_test_set_primary_path_idx(mqvpn_client_t *c, int idx);
+extern int mqvpn_client_test_get_fd_for_path(mqvpn_client_t *c, uint64_t xqc_path_id);
+extern int mqvpn_client_test_next_primary_idx(const mqvpn_client_t *c, int from_idx);
+
+TEST(get_fd_prefers_rotated_primary_when_active)
+{
+    mqvpn_client_t *c = make_test_client();
+    mqvpn_path_desc_t d0 = {0};
+    snprintf(d0.iface, sizeof(d0.iface), "eth0");
+    mqvpn_path_handle_t h0 = mqvpn_client_add_path_fd(c, 10, &d0);
+    ASSERT_NE(h0, (mqvpn_path_handle_t)-1);
+
+    mqvpn_path_desc_t d1 = {0};
+    snprintf(d1.iface, sizeof(d1.iface), "wlan0");
+    mqvpn_path_handle_t h1 = mqvpn_client_add_path_fd(c, 11, &d1);
+    ASSERT_NE(h1, (mqvpn_path_handle_t)-1);
+
+    /* Rotate primary to slot 1 — both slots are active. The fallback
+     * MUST honour the rotation and return slot 1's fd, not paths[0].fd. */
+    ASSERT_EQ(mqvpn_client_test_set_primary_path_idx(c, 1), 0);
+
+    /* xqc_path_id 99999 is unknown → triggers the fallback. */
+    ASSERT_EQ(mqvpn_client_test_get_fd_for_path(c, 99999), 11);
+
+    mqvpn_client_destroy(c);
+}
+
+TEST(get_fd_falls_back_to_first_active_when_primary_dropped)
+{
+    mqvpn_client_t *c = make_test_client();
+    mqvpn_path_desc_t d0 = {0};
+    snprintf(d0.iface, sizeof(d0.iface), "eth0");
+    mqvpn_path_handle_t h0 = mqvpn_client_add_path_fd(c, 10, &d0);
+    ASSERT_NE(h0, (mqvpn_path_handle_t)-1);
+
+    mqvpn_path_desc_t d1 = {0};
+    snprintf(d1.iface, sizeof(d1.iface), "wlan0");
+    mqvpn_path_handle_t h1 = mqvpn_client_add_path_fd(c, 11, &d1);
+    ASSERT_NE(h1, (mqvpn_path_handle_t)-1);
+
+    /* primary_path_idx=0 (default). Drop the primary slot — its `active`
+     * flag clears but the platform owns fd lifecycle so the fd field
+     * remains. The fallback must skip to slot 1 instead of handing back
+     * the dead primary's stale fd. */
+    ASSERT_EQ(mqvpn_client_test_set_primary_path_idx(c, 0), 0);
+    ASSERT_EQ(mqvpn_client_drop_path(c, h0), MQVPN_OK);
+
+    ASSERT_EQ(mqvpn_client_test_get_fd_for_path(c, 99999), 11);
+
+    mqvpn_client_destroy(c);
+}
+
+TEST(client_next_primary_idx_skips_closed_and_inactive)
+{
+    mqvpn_client_t *c = make_test_client();
+
+    /* 3 paths. We will mark slot 0 CLOSED (via remove_path) and slot 1
+     * inactive (via drop_path; its `active` flag clears). Slot 2 stays
+     * healthy. Rotation from slot 0 must skip both unreachable slots
+     * and land on slot 2. */
+    mqvpn_path_desc_t d0 = {0};
+    snprintf(d0.iface, sizeof(d0.iface), "eth0");
+    mqvpn_path_handle_t h0 = mqvpn_client_add_path_fd(c, 10, &d0);
+    ASSERT_NE(h0, (mqvpn_path_handle_t)-1);
+
+    mqvpn_path_desc_t d1 = {0};
+    snprintf(d1.iface, sizeof(d1.iface), "wlan0");
+    mqvpn_path_handle_t h1 = mqvpn_client_add_path_fd(c, 11, &d1);
+    ASSERT_NE(h1, (mqvpn_path_handle_t)-1);
+
+    mqvpn_path_desc_t d2 = {0};
+    snprintf(d2.iface, sizeof(d2.iface), "usb0");
+    mqvpn_path_handle_t h2 = mqvpn_client_add_path_fd(c, 12, &d2);
+    ASSERT_NE(h2, (mqvpn_path_handle_t)-1);
+
+    /* remove_path → status=CLOSED + active=0 (predicate excludes BOTH). */
+    ASSERT_EQ(mqvpn_client_remove_path(c, h0), MQVPN_OK);
+    /* drop_path → status=CLOSED + active=0 too; equivalent for rotation. */
+    ASSERT_EQ(mqvpn_client_drop_path(c, h1), MQVPN_OK);
+
+    /* Sanity: from slot 2, rotation wraps full circle and only slot 2
+     * itself qualifies — but the helper looks at OTHER slots first. With
+     * slots 0,1 unreachable it returns from_idx (=2) per the fail-safe. */
+    ASSERT_EQ(mqvpn_client_test_next_primary_idx(c, 2), 2);
+
+    /* From slot 0, walks 1 → 2 → finds 2 active. */
+    ASSERT_EQ(mqvpn_client_test_next_primary_idx(c, 0), 2);
+
+    /* From slot 1, walks 2 → finds 2 active. */
+    ASSERT_EQ(mqvpn_client_test_next_primary_idx(c, 1), 2);
+
+    mqvpn_client_destroy(c);
+}
+
 /* ── Path reactivation preconditions ── */
 
 TEST(reactivate_path_null_client)
@@ -1235,6 +1343,11 @@ main(void)
     run_drop_path_emits_closed_event_when_active();
     run_drop_path_does_not_emit_when_already_closed();
     run_rollback_after_activation_failure_emits_degraded_then_closed();
+
+    /* Primary-path rotation (issue #46) + OMR fallback composite */
+    run_get_fd_prefers_rotated_primary_when_active();
+    run_get_fd_falls_back_to_first_active_when_primary_dropped();
+    run_client_next_primary_idx_skips_closed_and_inactive();
 
     /* Path reactivation tests */
     run_reactivate_path_null_client();


### PR DESCRIPTION
fix #46 
When the first configured Path had no upstream connectivity, the QUIC handshake always retried on the same dead path and the VPN interface never came up. Rotate primary_path_idx through active paths on each reconnect so the client eventually tries a working path.