### PR TITLE
fix(client): close path immediately on -XQC_EMP_CREATE_PATH (budget exhaust / OOM)

### DIFF
--- a/src/mqvpn_client.c
+++ b/src/mqvpn_client.c
@@ -1153,6 +1153,7 @@ cb_dgram_mss_updated(xqc_h3_conn_t *h, size_t mss, void *ud)
  * retry-related siblings (path_recreate_backoff, etc.). */
 static void apply_path_activation_failure(mqvpn_client_t *c, path_entry_t *p,
                                           uint64_t now_us);
+static void apply_path_create_permanent_failure(mqvpn_client_t *c, path_entry_t *p);
 
 /* Create an xquic path for a secondary path entry and mark it ACTIVE.
  *
@@ -1168,12 +1169,26 @@ client_activate_path(mqvpn_client_t *c, path_entry_t *p, int idx)
     xqc_int_t ret = xqc_conn_create_path(c->engine, &c->conn->cid, &new_id, path_status);
     if (ret < 0) {
         LOG_W(c, "xqc_conn_create_path[%d]: %d", idx, ret);
-        /* Schedule a retry so the path is not stuck in PENDING/ACTIVE
-         * forever — the tick recovery loop only services DEGRADED slots
-         * with a non-zero recreate_after_us.  Common trigger: the server
-         * has not yet distributed enough CIDs for additional paths
-         * (-XQC_EMP_NO_AVAIL_PATH_ID).  Backport of Ysurac 86c275c
-         * (issue Ysurac/openmptcprouter#4271 Bug 1). */
+        if (ret == -XQC_EMP_CREATE_PATH) {
+            /* Permanent failure on this connection. Two triggers:
+             *   1. XQC_MAX_PATHS_COUNT cap hit (`xqc_path_create|too many paths`)
+             *   2. xqc_calloc OOM inside xqc_path_create
+             * Both are unrecoverable in-conn — the path_id namespace only
+             * resets on Level-2 reconnect. Skip the DEGRADED retry path so
+             * neither tick_recover_degraded_path nor the platform's 3s
+             * recovery timer busy-loops on calls that will never succeed. */
+            apply_path_create_permanent_failure(c, p);
+            LOG_W(c,
+                  "path closed: %s (xquic path budget exhausted/OOM, requires reconnect)",
+                  p->name);
+            return;
+        }
+        /* Other errors (e.g. -XQC_EMP_NO_AVAIL_PATH_ID — server hasn't
+         * distributed enough CIDs yet) are transient. Schedule a retry so
+         * the path is not stuck in PENDING/ACTIVE forever — the tick
+         * recovery loop only services DEGRADED slots with non-zero
+         * recreate_after_us. Backport of Ysurac 86c275c (issue
+         * Ysurac/openmptcprouter#4271 Bug 1). */
         apply_path_activation_failure(c, p, client_now_us(c));
         if (p->status == MQVPN_PATH_CLOSED) {
             LOG_W(c, "path closed: %s (retries exhausted at activation)", p->name);
@@ -1277,6 +1292,40 @@ mqvpn_client_apply_path_activation_failure(mqvpn_client_t *c, mqvpn_path_handle_
     path_entry_t *p = find_path_by_handle(c, handle);
     if (!p) return -1;
     apply_path_activation_failure(c, p, now_us);
+    return 0;
+}
+
+/* Apply a permanent (non-retryable) path-creation failure — used when
+ * xqc_conn_create_path() returns -XQC_EMP_CREATE_PATH (XQC_MAX_PATHS_COUNT
+ * cap hit, or xqc_calloc OOM). Marks the slot CLOSED and clears retry
+ * scheduling so neither tick_recover_degraded_path nor the platform's
+ * recovery timer attempt to retry. Recovery requires a Level-2 reconnect
+ * which resets xquic's path_id namespace. */
+static void
+apply_path_create_permanent_failure(mqvpn_client_t *c, path_entry_t *p)
+{
+    p->in_use = 0;
+    p->xqc_path_id = 0;
+    p->path_stable_since_us = 0;
+    p->status = MQVPN_PATH_CLOSED;
+    p->recreate_after_us = 0;
+    p->recreate_retries = 0;
+    if (c->cbs.path_event) c->cbs.path_event(p->handle, MQVPN_PATH_CLOSED, c->user_ctx);
+}
+
+/* Test-only wrapper: drives apply_path_create_permanent_failure() by
+ * handle. Hidden from libmqvpn.so's dynamic export table. */
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((visibility("hidden")))
+#endif
+int
+mqvpn_client_test_apply_path_create_permanent_failure(mqvpn_client_t *c,
+                                                      mqvpn_path_handle_t handle)
+{
+    if (!c) return -1;
+    path_entry_t *p = find_path_by_handle(c, handle);
+    if (!p) return -1;
+    apply_path_create_permanent_failure(c, p);
     return 0;
 }
 

--- a/src/platform/linux/platform_linux.c
+++ b/src/platform/linux/platform_linux.c
@@ -635,37 +635,58 @@ try_readd_removed_path(platform_ctx_t *p, const char *ifname)
 
         /* Verify activation. cb_path_event(ACTIVE) already fired inside
          * add_path_fd() but couldn't match our slot (lib_path_handles[i]
-         * wasn't stored yet). Query path status explicitly instead. */
+         * wasn't stored yet). Query path status explicitly instead.
+         *
+         * Three observable outcomes:
+         *   ACTIVE   — happy path, take the success branch below.
+         *   DEGRADED — apply_path_activation_failure scheduled a retry on
+         *              transient errors (e.g. -XQC_EMP_NO_AVAIL_PATH_ID
+         *              when CIDs not yet distributed). Roll back and let
+         *              the 3s recovery timer try again.
+         *   CLOSED   — apply_path_create_permanent_failure ran, meaning
+         *              xqc_conn_create_path returned -XQC_EMP_CREATE_PATH
+         *              (XQC_MAX_PATHS_COUNT cap or OOM). Retrying within
+         *              this connection cannot succeed — clear the timer
+         *              eligibility flag so we stop busy-looping. */
         mqvpn_path_info_t pinfo[MQVPN_MAX_PATHS];
         int n_info = 0;
         mqvpn_client_get_paths(p->client, pinfo, MQVPN_MAX_PATHS, &n_info);
         int activated = 0;
+        int permanent_closed = 0;
         for (int j = 0; j < n_info; j++) {
-            if (pinfo[j].handle == handle && pinfo[j].status == MQVPN_PATH_ACTIVE) {
+            if (pinfo[j].handle != handle) continue;
+            if (pinfo[j].status == MQVPN_PATH_ACTIVE)
                 activated = 1;
-                break;
-            }
+            else if (pinfo[j].status == MQVPN_PATH_CLOSED)
+                permanent_closed = 1;
+            break;
         }
 
         if (!activated) {
-            /* Activation failed (xqc_conn_create_path error) — slot is
-             * DEGRADED + active=1 + in_use=0 (apply_path_activation_failure
-             * transitioned PENDING → DEGRADED and explicitly cleared
-             * in_use/xqc_path_id/path_stable_since_us). Undo everything so
-             * the platform's path_removed_by_platform=1 retry loop owns
-             * recovery instead of the library's tick recovery
-             * (path_removed_by_platform stays 1, fd reverts to -1).
+            /* Roll back so the next attempt (timer or netlink event) starts
+             * from a clean slate.
              *
              * Safe ordering: remove_path() first, then close(fd). The
-             * in_use=0 invariant (enforced by apply_path_activation_failure)
-             * makes remove_path() skip xqc_conn_close_path(), so xquic
-             * never touches this fd during teardown. Do NOT remove that
-             * defensive clear — it's what makes this rollback safe. */
+             * in_use=0 invariant (enforced by apply_path_activation_failure
+             * / apply_path_create_permanent_failure) makes remove_path()
+             * skip xqc_conn_close_path(), so xquic never touches this fd
+             * during teardown. Do NOT remove that defensive clear — it's
+             * what makes this rollback safe. */
             LOG_WRN("netlink: re-add %s not activated, will retry", ifname);
             mqvpn_client_remove_path(p->client, handle);
             close(fd);
             mp->fd = -1;
             mp->active = 0;
+            if (permanent_closed) {
+                /* xquic budget exhausted — disable the 3s recovery timer
+                 * for this slot. The path stays in path_removed_by_platform
+                 * = 0 until either a new netlink event reactivates it or
+                 * a Level-2 reconnect resets the path_id namespace. */
+                p->path_removed_by_platform[i] = 0;
+                LOG_WRN("netlink: path %s recovery abandoned (xquic budget "
+                        "exhausted; reconnect required)",
+                        ifname);
+            }
             return 0;
         }
 

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -985,6 +985,67 @@ TEST(activation_failure_eventually_closes_path)
     mqvpn_client_destroy(c);
 }
 
+/* ── Permanent path-create failure (xquic budget exhausted / OOM) ──
+ *
+ * When xqc_conn_create_path() returns -XQC_EMP_CREATE_PATH (652), retrying
+ * within the same connection cannot succeed — XQC_MAX_PATHS_COUNT is
+ * structural, and OOM in xqc_path_create's xqc_calloc is similarly
+ * unrecoverable in-conn. The slot must transition straight to CLOSED
+ * (no DEGRADED retry path) so the recovery timer / tick recovery loop
+ * stop busy-looping on calls that will never succeed. */
+
+extern int
+mqvpn_client_test_apply_path_create_permanent_failure(mqvpn_client_t *c,
+                                                      mqvpn_path_handle_t handle);
+
+TEST(path_create_permanent_failure_marks_closed_immediately)
+{
+    mqvpn_client_t *c = make_test_client();
+    mqvpn_path_handle_t h = mqvpn_client_add_path_fd(c, 42, NULL);
+    ASSERT_NE(h, (mqvpn_path_handle_t)-1);
+
+    /* Slot is freshly added: status=PENDING, active=1. */
+    mqvpn_path_info_t info[2];
+    int n = 0;
+    mqvpn_client_get_paths(c, info, 2, &n);
+    ASSERT_EQ(n, 1);
+    ASSERT_EQ(info[0].status, MQVPN_PATH_PENDING);
+
+    ASSERT_EQ(mqvpn_client_test_apply_path_create_permanent_failure(c, h), 0);
+
+    /* MUST be CLOSED — not DEGRADED — so tick_recover_degraded_path doesn't
+     * pick it up. */
+    mqvpn_client_get_paths(c, info, 2, &n);
+    ASSERT_EQ(n, 1);
+    ASSERT_EQ(info[0].status, MQVPN_PATH_CLOSED);
+
+    mqvpn_client_destroy(c);
+}
+
+TEST(path_create_permanent_failure_emits_closed_event)
+{
+    mqvpn_client_t *c = make_test_client();
+    mqvpn_path_handle_t h = mqvpn_client_add_path_fd(c, 42, NULL);
+    ASSERT_NE(h, (mqvpn_path_handle_t)-1);
+
+    g_path_event_count = 0;
+    ASSERT_EQ(mqvpn_client_test_apply_path_create_permanent_failure(c, h), 0);
+
+    /* path_event(handle, CLOSED) must fire so observers see lifecycle end. */
+    ASSERT_EQ(g_path_event_count, 1);
+    ASSERT_EQ(g_last_path_event_handle, h);
+    ASSERT_EQ(g_last_path_event_status, MQVPN_PATH_CLOSED);
+
+    mqvpn_client_destroy(c);
+}
+
+TEST(path_create_permanent_failure_invalid_handle_returns_error)
+{
+    mqvpn_client_t *c = make_test_client();
+    ASSERT_EQ(mqvpn_client_test_apply_path_create_permanent_failure(c, 99999), -1);
+    mqvpn_client_destroy(c);
+}
+
 /* ── path_event close-out semantics ──
  *
  * remove_path / drop_path transition a non-CLOSED slot to CLOSED. The
@@ -1348,6 +1409,11 @@ main(void)
     run_get_fd_prefers_rotated_primary_when_active();
     run_get_fd_falls_back_to_first_active_when_primary_dropped();
     run_client_next_primary_idx_skips_closed_and_inactive();
+
+    /* Permanent path-create failure (XQC_EMP_CREATE_PATH) */
+    run_path_create_permanent_failure_marks_closed_immediately();
+    run_path_create_permanent_failure_emits_closed_event();
+    run_path_create_permanent_failure_invalid_handle_returns_error();
 
     /* Path reactivation tests */
     run_reactivate_path_null_client();


### PR DESCRIPTION
Once xquic returns -XQC_EMP_CREATE_PATH (652) the failure is permanent within the current connection: it's raised when xqc_path_create returns NULL, which happens for either XQC_MAX_PATHS_COUNT cap exhaustion or xqc_calloc OOM. Both are unrecoverable without reconnecting, because xquic's path_id namespace only resets when the connection is torn down (Level-2 reconnect).

Library side
  Special-case ret == -XQC_EMP_CREATE_PATH in client_activate_path:
  invoke a new apply_path_create_permanent_failure() helper that marks
  the slot CLOSED, clears in_use / xqc_path_id / path_stable_since_us,
  and zeroes recreate_after_us / recreate_retries. The CLOSED status
  excludes the slot from tick_recover_degraded_path automatically.
  path_event(handle, CLOSED) is emitted so observers see the lifecycle
  end. -XQC_EMP_NO_AVAIL_PATH_ID (transient — server hasn't distributed
  enough CIDs) continues to flow into the existing DEGRADED retry path
  unchanged.

Platform side
  try_readd_removed_path now distinguishes DEGRADED (retryable) from
  CLOSED (give up) when querying the slot status post-add_path_fd. On
  CLOSED it clears path_removed_by_platform[i], which silences the 3s
  recovery timer for this slot. The slot re-arms naturally on a new
  netlink event (cable replug → drop_path then carrier-up re-add) or
  on Level-2 reconnect (fresh path_id namespace).