### PR TITLE
client: abort handshake after 5s stall to rotate primary path

### DIFF
--- a/src/mqvpn_client.c
+++ b/src/mqvpn_client.c
@@ -43,11 +43,15 @@
 
 /* ─── Constants ─── */
 
-#define PACKET_BUF_SIZE            65536
-#define MASQUE_FRAME_BUF           (PACKET_BUF_SIZE + 16)
-#define MAX_CAPSULE_BUF            65536
-#define XQC_SNDQ_MAX_PKTS          16384
-#define RECONNECT_BACKOFF_MAX_SEC  60
+#define PACKET_BUF_SIZE           65536
+#define MASQUE_FRAME_BUF          (PACKET_BUF_SIZE + 16)
+#define MAX_CAPSULE_BUF           65536
+#define XQC_SNDQ_MAX_PKTS         16384
+#define RECONNECT_BACKOFF_MAX_SEC 60
+/* Force-close the QUIC handshake if it doesn't progress past CONNECTING within
+ * this window, so a dead first-listed path triggers reconnect (and primary_path_idx
+ * rotation, issue #46) rather than waiting for xquic's idle_time_out (120s). */
+#define HANDSHAKE_STALL_TIMEOUT_MS 5000
 #define PTB_RATE_LIMIT             10
 #define PATH_RECREATE_DELAY_US     (5ULL * 1000000)  /* 5 sec initial */
 #define PATH_RECREATE_MAX_DELAY_US (60ULL * 1000000) /* 60 sec max backoff */
@@ -179,6 +183,11 @@ struct mqvpn_client_s {
     /* Timer: next wake (from xquic set_event_timer) */
     uint64_t next_wake_us;
 
+    /* Handshake stall watchdog. Set when entering CONNECTING, cleared on every
+     * exit transition. Used to abort a CONNECTING that is making no progress
+     * (typically a dead primary path) before xquic's 120s idle_time_out. */
+    uint64_t handshake_started_us;
+
     /* ICMP PTB rate limit */
     int ptb_tokens;
     int64_t ptb_refill_ms;
@@ -301,8 +310,23 @@ client_set_state(mqvpn_client_t *c, mqvpn_client_state_t new_state)
     if (old == new_state) return;
     assert(mqvpn_state_transition_valid(old, new_state) &&
            "mqvpn_client: invalid state transition");
+    if (new_state == MQVPN_STATE_CONNECTING) {
+        c->handshake_started_us = client_now_us(c);
+    } else if (old == MQVPN_STATE_CONNECTING) {
+        c->handshake_started_us = 0;
+    }
     c->state = new_state;
     if (c->cbs.state_changed) c->cbs.state_changed(old, new_state, c->user_ctx);
+}
+
+static int
+client_handshake_stalled(const mqvpn_client_t *c, uint64_t now_us)
+{
+    if (c->state != MQVPN_STATE_CONNECTING) return 0;
+    if (c->handshake_started_us == 0) return 0;
+    if (now_us <= c->handshake_started_us) return 0;
+    uint64_t elapsed = now_us - c->handshake_started_us;
+    return elapsed >= (uint64_t)HANDSHAKE_STALL_TIMEOUT_MS * 1000;
 }
 
 #ifndef NDEBUG
@@ -458,6 +482,48 @@ mqvpn_client_test_next_primary_idx(const mqvpn_client_t *c, int from_idx)
 {
     if (!c) return -1;
     return client_next_primary_idx(c, from_idx);
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((visibility("hidden")))
+#endif
+uint64_t
+mqvpn_client_test_get_handshake_started_us(const mqvpn_client_t *c)
+{
+    if (!c) return 0;
+    return c->handshake_started_us;
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((visibility("hidden")))
+#endif
+int
+mqvpn_client_test_set_handshake_started_us(mqvpn_client_t *c, uint64_t us)
+{
+    if (!c) return -1;
+    c->handshake_started_us = us;
+    return 0;
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((visibility("hidden")))
+#endif
+int
+mqvpn_client_test_handshake_stalled(const mqvpn_client_t *c, uint64_t now_us)
+{
+    if (!c) return -1;
+    return client_handshake_stalled(c, now_us) ? 1 : 0;
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((visibility("hidden")))
+#endif
+int
+mqvpn_client_test_force_state(mqvpn_client_t *c, mqvpn_client_state_t s)
+{
+    if (!c) return -1;
+    client_set_state(c, s);
+    return 0;
 }
 
 /* ─── ICMP PTB rate limiter ─── */
@@ -2053,6 +2119,41 @@ tick_reconnect(mqvpn_client_t *c)
     }
 }
 
+/* ─── Tick: handshake stall watchdog ─── */
+
+static void
+tick_handshake_watchdog(mqvpn_client_t *c)
+{
+    if (c->shutting_down) return;
+    if (!client_handshake_stalled(c, client_now_us(c))) return;
+
+    const char *iface = "?";
+    if (c->primary_path_idx >= 0 && c->primary_path_idx < c->n_paths) {
+        iface = c->paths[c->primary_path_idx].name;
+    }
+    LOG_W(c, "handshake stalled %dms on path[%d] (%s); aborting to rotate",
+          HANDSHAKE_STALL_TIMEOUT_MS, c->primary_path_idx, iface);
+
+    /* Clear immediately so xqc_engine_main_logic running below can fire
+     * cb_h3_conn_close synchronously without the watchdog re-firing. */
+    c->handshake_started_us = 0;
+
+    if (c->engine && c->conn) {
+        /* xqc_h3_conn_close marks the conn for close. Engine drains it on
+         * the next main_logic call (already queued in mqvpn_client_tick after
+         * this watchdog) and fires cb_h3_conn_close, which arms the reconnect
+         * timer; tick_reconnect → client_reset_paths_for_reconnect rotates
+         * primary_path_idx so the dead first path is skipped. */
+        xqc_h3_conn_close(c->engine, &c->conn->cid);
+    } else {
+        /* No live conn (cli_start_connection failed earlier) — shortcut to
+         * reconnect via the same code path. Rotation still happens in
+         * client_reset_paths_for_reconnect. */
+        client_arm_reconnect_timer(c);
+        client_set_state(c, MQVPN_STATE_RECONNECTING);
+    }
+}
+
 /* ─── Tick ─── */
 
 int
@@ -2061,6 +2162,7 @@ mqvpn_client_tick(mqvpn_client_t *c)
     if (!c) return MQVPN_ERR_INVALID_ARG;
     ASSERT_TICK_THREAD(c);
 
+    tick_handshake_watchdog(c);
     if (c->engine) xqc_engine_main_logic(c->engine);
     tick_path_recovery(c);
     tick_reconnect(c);
@@ -2152,6 +2254,17 @@ mqvpn_client_get_interest(const mqvpn_client_t *c, mqvpn_interest_t *out)
         } else {
             ms = 1; /* reconnect is due */
         }
+    }
+
+    /* During CONNECTING, wake up no later than the handshake stall deadline
+     * so tick_handshake_watchdog can fire even if no packets arrive (a dead
+     * primary path produces zero recv events). */
+    if (c->state == MQVPN_STATE_CONNECTING && c->handshake_started_us > 0) {
+        uint64_t deadline =
+            c->handshake_started_us + (uint64_t)HANDSHAKE_STALL_TIMEOUT_MS * 1000;
+        uint64_t now_val = client_now_us(c);
+        int hms = (deadline > now_val) ? (int)((deadline - now_val) / 1000) : 1;
+        if (ms <= 0 || hms < ms) ms = hms;
     }
 
     /* Account for path recovery and stability timers */

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -1272,6 +1272,145 @@ TEST(client_next_primary_idx_skips_closed_and_inactive)
     mqvpn_client_destroy(c);
 }
 
+/* ── Handshake stall watchdog ──
+ *
+ * If the QUIC handshake doesn't progress past CONNECTING within
+ * HANDSHAKE_STALL_TIMEOUT_MS (10s), the watchdog forces close → reconnect →
+ * primary_path_idx rotates (issue #46 mechanism), so a dead first-listed path
+ * recovers in ~15s instead of waiting 120s for xquic's idle_time_out. */
+
+extern uint64_t mqvpn_client_test_get_handshake_started_us(const mqvpn_client_t *c);
+extern int mqvpn_client_test_set_handshake_started_us(mqvpn_client_t *c, uint64_t us);
+extern int mqvpn_client_test_handshake_stalled(const mqvpn_client_t *c, uint64_t now_us);
+extern int mqvpn_client_test_force_state(mqvpn_client_t *c, mqvpn_client_state_t s);
+
+#define STALL_THRESHOLD_US ((uint64_t)5 * 1000 * 1000)
+
+TEST(handshake_stall_not_triggered_when_idle)
+{
+    mqvpn_client_t *c = make_test_client();
+    /* IDLE: no handshake in progress, started_us=0 */
+    ASSERT_EQ(mqvpn_client_test_handshake_stalled(c, STALL_THRESHOLD_US * 10), 0);
+    mqvpn_client_destroy(c);
+}
+
+TEST(handshake_stall_not_triggered_within_threshold)
+{
+    mqvpn_client_t *c = make_test_client();
+    ASSERT_EQ(mqvpn_client_test_force_state(c, MQVPN_STATE_CONNECTING), 0);
+
+    uint64_t started = 1000000; /* arbitrary, deterministic */
+    ASSERT_EQ(mqvpn_client_test_set_handshake_started_us(c, started), 0);
+
+    /* now = started + 4s : below 5s threshold */
+    uint64_t now = started + 4 * 1000000;
+    ASSERT_EQ(mqvpn_client_test_handshake_stalled(c, now), 0);
+
+    mqvpn_client_destroy(c);
+}
+
+TEST(handshake_stall_triggered_after_threshold)
+{
+    mqvpn_client_t *c = make_test_client();
+    ASSERT_EQ(mqvpn_client_test_force_state(c, MQVPN_STATE_CONNECTING), 0);
+
+    uint64_t started = 1000000;
+    ASSERT_EQ(mqvpn_client_test_set_handshake_started_us(c, started), 0);
+
+    /* now = started + 6s : exceeds 5s threshold */
+    uint64_t now = started + 6 * 1000000;
+    ASSERT_EQ(mqvpn_client_test_handshake_stalled(c, now), 1);
+
+    mqvpn_client_destroy(c);
+}
+
+TEST(handshake_stall_only_in_connecting_state)
+{
+    mqvpn_client_t *c = make_test_client();
+
+    /* Walk through valid transitions to AUTHENTICATING and verify the
+     * watchdog does NOT fire there — AUTHENTICATING means the QUIC handshake
+     * already succeeded; subsequent stalls are a different failure mode and
+     * out of scope for this watchdog. */
+    ASSERT_EQ(mqvpn_client_test_force_state(c, MQVPN_STATE_CONNECTING), 0);
+    ASSERT_EQ(mqvpn_client_test_force_state(c, MQVPN_STATE_AUTHENTICATING), 0);
+
+    uint64_t now = 1000000 + 30 * 1000000;
+    /* Even with a (stale) started_us deeply in the past, AUTHENTICATING
+     * must not be flagged as stalled. */
+    ASSERT_EQ(mqvpn_client_test_set_handshake_started_us(c, 1000000), 0);
+    ASSERT_EQ(mqvpn_client_test_handshake_stalled(c, now), 0);
+
+    mqvpn_client_destroy(c);
+}
+
+TEST(client_set_state_to_connecting_records_handshake_start)
+{
+    mqvpn_client_t *c = make_test_client();
+    ASSERT_EQ(mqvpn_client_test_get_handshake_started_us(c), 0u);
+
+    ASSERT_EQ(mqvpn_client_test_force_state(c, MQVPN_STATE_CONNECTING), 0);
+    /* Real wall clock used (no clock_fn injected on test client) — we can
+     * only assert non-zero, not a specific value. */
+    ASSERT_NE(mqvpn_client_test_get_handshake_started_us(c), 0u);
+
+    mqvpn_client_destroy(c);
+}
+
+TEST(client_set_state_leaving_connecting_clears_handshake_start)
+{
+    mqvpn_client_t *c = make_test_client();
+
+    ASSERT_EQ(mqvpn_client_test_force_state(c, MQVPN_STATE_CONNECTING), 0);
+    ASSERT_NE(mqvpn_client_test_get_handshake_started_us(c), 0u);
+
+    /* AUTHENTICATING means handshake succeeded — clear the watchdog. */
+    ASSERT_EQ(mqvpn_client_test_force_state(c, MQVPN_STATE_AUTHENTICATING), 0);
+    ASSERT_EQ(mqvpn_client_test_get_handshake_started_us(c), 0u);
+
+    mqvpn_client_destroy(c);
+}
+
+TEST(client_set_state_reconnecting_clears_handshake_start)
+{
+    mqvpn_client_t *c = make_test_client();
+
+    ASSERT_EQ(mqvpn_client_test_force_state(c, MQVPN_STATE_CONNECTING), 0);
+    ASSERT_NE(mqvpn_client_test_get_handshake_started_us(c), 0u);
+
+    /* RECONNECTING is the path the watchdog itself triggers (via
+     * cb_h3_conn_close); clearing here prevents a stale started_us from
+     * being mistaken as "still in CONNECTING for a long time" if we later
+     * re-enter CONNECTING and the new attempt should restart the timer. */
+    ASSERT_EQ(mqvpn_client_test_force_state(c, MQVPN_STATE_RECONNECTING), 0);
+    ASSERT_EQ(mqvpn_client_test_get_handshake_started_us(c), 0u);
+
+    mqvpn_client_destroy(c);
+}
+
+TEST(get_interest_includes_handshake_stall_deadline)
+{
+    mqvpn_client_t *c = make_test_client();
+
+    ASSERT_EQ(mqvpn_client_test_force_state(c, MQVPN_STATE_CONNECTING), 0);
+    /* started_us=0 sentinel means "no active stall watch" — get_interest
+     * must not be misled by an explicitly cleared timer. We instead trust
+     * the value just set by client_set_state. */
+    uint64_t started = mqvpn_client_test_get_handshake_started_us(c);
+    ASSERT_NE(started, 0u);
+
+    mqvpn_interest_t i = {0};
+    i.struct_size = sizeof(i);
+    ASSERT_EQ(mqvpn_client_get_interest(c, &i), MQVPN_OK);
+
+    /* Watchdog fires no later than 5s from started_us. next_timer_ms must
+     * not exceed that, else the platform's libevent timer would not wake the
+     * client to run the watchdog before idle_time_out (120s) takes over. */
+    ASSERT_EQ(i.next_timer_ms <= 5000, 1);
+
+    mqvpn_client_destroy(c);
+}
+
 /* ── Path reactivation preconditions ── */
 
 TEST(reactivate_path_null_client)
@@ -1414,6 +1553,16 @@ main(void)
     run_path_create_permanent_failure_marks_closed_immediately();
     run_path_create_permanent_failure_emits_closed_event();
     run_path_create_permanent_failure_invalid_handle_returns_error();
+
+    /* Handshake stall watchdog */
+    run_handshake_stall_not_triggered_when_idle();
+    run_handshake_stall_not_triggered_within_threshold();
+    run_handshake_stall_triggered_after_threshold();
+    run_handshake_stall_only_in_connecting_state();
+    run_client_set_state_to_connecting_records_handshake_start();
+    run_client_set_state_leaving_connecting_clears_handshake_start();
+    run_client_set_state_reconnecting_clears_handshake_start();
+    run_get_interest_includes_handshake_stall_deadline();
 
     /* Path reactivation tests */
     run_reactivate_path_null_client();


### PR DESCRIPTION
#46 (4a599f7) added rotate-on-reconnect for a dead first-listed path, but assumed xquic's init_idle_time_out (10s) would close the conn and fire cb_h3_conn_close. xqc_conn_get_idle_timeout limits that to server conns only — clients fall through to idle_time_out (120s), so rotation didn't happen until 2 minutes had passed.

Watchdog in tick: state==CONNECTING with elapsed >= 5s → xqc_h3_conn_close → existing reconnect path → primary_path_idx rotate. Recovery: 5s + 5s reconnect = 10s instead of 125s.

mqvpn_client_get_interest now reports the stall deadline in next_timer_ms so the platform's libevent timer wakes the client even when no packets arrive (a dead path produces zero recv events).