### PR TITLE
Feat/configurable tun mtu

### DIFF
--- a/include/libmqvpn.h
+++ b/include/libmqvpn.h
@@ -409,6 +409,7 @@ MQVPN_API int mqvpn_config_set_killswitch_hint(mqvpn_config_t *cfg, int enable);
  * 0 = use xquic default (XQC_DEFAULT_INIT_MAX_PATH_ID = 8). Set lower
  * (e.g. 2) to deterministically trigger G-P16 PATHS_BLOCKED. */
 MQVPN_API int mqvpn_config_set_init_max_path_id(mqvpn_config_t *cfg, uint64_t v);
+/* TUN MTU cap: 0 = auto (MSS-derived), 1280..65535 = upper bound. */
 MQVPN_API int mqvpn_config_set_tun_mtu(mqvpn_config_t *cfg, int mtu);
 
 /* Clock injection (Android: CLOCK_BOOTTIME, testing: mock clock) */

--- a/include/libmqvpn.h
+++ b/include/libmqvpn.h
@@ -409,6 +409,7 @@ MQVPN_API int mqvpn_config_set_killswitch_hint(mqvpn_config_t *cfg, int enable);
  * 0 = use xquic default (XQC_DEFAULT_INIT_MAX_PATH_ID = 8). Set lower
  * (e.g. 2) to deterministically trigger G-P16 PATHS_BLOCKED. */
 MQVPN_API int mqvpn_config_set_init_max_path_id(mqvpn_config_t *cfg, uint64_t v);
+MQVPN_API int mqvpn_config_set_tun_mtu(mqvpn_config_t *cfg, int mtu);
 
 /* Clock injection (Android: CLOCK_BOOTTIME, testing: mock clock) */
 typedef uint64_t (*mqvpn_clock_fn)(void *ctx);

--- a/include/libmqvpn.h
+++ b/include/libmqvpn.h
@@ -409,7 +409,7 @@ MQVPN_API int mqvpn_config_set_killswitch_hint(mqvpn_config_t *cfg, int enable);
  * 0 = use xquic default (XQC_DEFAULT_INIT_MAX_PATH_ID = 8). Set lower
  * (e.g. 2) to deterministically trigger G-P16 PATHS_BLOCKED. */
 MQVPN_API int mqvpn_config_set_init_max_path_id(mqvpn_config_t *cfg, uint64_t v);
-/* TUN MTU cap: 0 = auto (MSS-derived), 1280..65535 = upper bound. */
+/* TUN MTU cap: 0 = auto (MSS-derived), 1280..9000 = upper bound. */
 MQVPN_API int mqvpn_config_set_tun_mtu(mqvpn_config_t *cfg, int mtu);
 
 /* Clock injection (Android: CLOCK_BOOTTIME, testing: mock clock) */

--- a/src/config.c
+++ b/src/config.c
@@ -266,6 +266,14 @@ handle_kv(mqvpn_file_config_t *cfg, int section, const char *key, const char *va
         } else if (strcasecmp(key, "ReconnectInterval") == 0) {
             int v = atoi(val);
             if (v > 0) cfg->reconnect_interval = v;
+        } else if (strcasecmp(key, "MTU") == 0) {
+            int v = atoi(val);
+            if (v != 0 && (v < 1280 || v > 65535)) {
+                LOG_WRN("%s:%d: MTU must be 1280..65535, got %d; ignoring", path, lineno,
+                        v);
+            } else {
+                cfg->tun_mtu = v;
+            }
         } else {
             LOG_WRN("%s:%d: unknown key '%s' in [Interface]", path, lineno, key);
         }
@@ -428,6 +436,15 @@ mqvpn_config_load_json_filecfg(mqvpn_file_config_t *cfg, const char *json_text)
 
     v = json_find_key(json_text, "kill_switch");
     if (v && json_read_bool(v, &iv) == 0) cfg->kill_switch = iv;
+
+    v = json_find_key(json_text, "mtu");
+    if (v && json_read_int(v, &iv) == 0) {
+        if (iv != 0 && (iv < 1280 || iv > 65535)) {
+            LOG_WRN("JSON: MTU must be 1280..65535, got %d; ignoring", iv);
+        } else {
+            cfg->tun_mtu = iv;
+        }
+    }
 
     v = json_find_key(json_text, "control_listen");
     if (v && json_read_string(v, s280, sizeof(s280)) == 0)

--- a/src/config.c
+++ b/src/config.c
@@ -268,8 +268,8 @@ handle_kv(mqvpn_file_config_t *cfg, int section, const char *key, const char *va
             if (v > 0) cfg->reconnect_interval = v;
         } else if (strcasecmp(key, "MTU") == 0) {
             int v = atoi(val);
-            if (v != 0 && (v < 1280 || v > 65535)) {
-                LOG_WRN("%s:%d: MTU must be 1280..65535, got %d; ignoring", path, lineno,
+            if (v != 0 && (v < 1280 || v > 9000)) {
+                LOG_WRN("%s:%d: MTU must be 1280..9000, got %d; ignoring", path, lineno,
                         v);
             } else {
                 cfg->tun_mtu = v;
@@ -440,7 +440,7 @@ mqvpn_config_load_json_filecfg(mqvpn_file_config_t *cfg, const char *json_text)
     v = json_find_key(json_text, "mtu");
     if (v && json_read_int(v, &iv) == 0) {
         if (iv != 0 && (iv < 1280 || iv > 65535)) {
-            LOG_WRN("JSON: MTU must be 1280..65535, got %d; ignoring", iv);
+            LOG_WRN("JSON: MTU must be 1280..9000, got %d; ignoring", iv);
         } else {
             cfg->tun_mtu = iv;
         }

--- a/src/config.h
+++ b/src/config.h
@@ -63,6 +63,8 @@ typedef struct mqvpn_file_config_s {
     int reconnect_interval; /* base interval in seconds (default 5) */
     int kill_switch;        /* 1=block traffic outside tunnel, 0=off (default) */
 
+    int tun_mtu; /* [Interface] MTU — 0=auto, >0=cap (floor 1280) */
+
     /* Inferred mode: 1=server, 0=client */
     int is_server;
 } mqvpn_file_config_t;

--- a/src/main.c
+++ b/src/main.c
@@ -467,6 +467,7 @@ main(int argc, char *argv[])
             .reconnect_interval = file_cfg.reconnect_interval,
             .kill_switch = kill_switch >= 0 ? kill_switch : file_cfg.kill_switch,
             .init_max_path_id = eff_init_max_path_id,
+            .tun_mtu = file_cfg.tun_mtu,
         };
         for (int i = 0; i < n_paths; i++) {
             cfg.path_ifaces[i] = path_ifaces[i];
@@ -510,6 +511,7 @@ main(int argc, char *argv[])
             .control_addr = eff_control_addr,
             .control_port = eff_control_port,
             .init_max_path_id = eff_init_max_path_id,
+            .tun_mtu = file_cfg.tun_mtu,
         };
         for (int i = 0; i < eff_n_users; i++) {
             cfg.user_names[i] = eff_user_names[i];

--- a/src/mqvpn_client.c
+++ b/src/mqvpn_client.c
@@ -1069,6 +1069,21 @@ cb_request_close(xqc_h3_request_t *h3_request, void *user_data)
 }
 
 static int
+apply_mtu_cap(int cfg_mtu, int negotiated, mqvpn_client_t *c)
+{
+    if (cfg_mtu > 0) {
+        if (cfg_mtu < negotiated) {
+            return cfg_mtu;
+        }
+        if (cfg_mtu > negotiated) {
+            LOG_W(c, "config MTU %d exceeds negotiated MTU %d, using %d", cfg_mtu,
+                  negotiated, negotiated);
+        }
+    }
+    return negotiated;
+}
+
+static int
 cb_request_read(xqc_h3_request_t *h3_request, xqc_request_notify_flag_t flag,
                 void *user_data)
 {
@@ -1112,6 +1127,7 @@ cb_request_read(xqc_h3_request_t *h3_request, xqc_request_notify_flag_t flag,
                 if (udp_mss >= 68) tun_mtu = (int)udp_mss;
             }
             if (conn->addr6_assigned && tun_mtu < IPV6_MIN_MTU) tun_mtu = IPV6_MIN_MTU;
+            tun_mtu = apply_mtu_cap(c->config.tun_mtu, tun_mtu, c);
             c->mtu = tun_mtu;
 
             /* Build tunnel info for callback */
@@ -1287,6 +1303,7 @@ cb_dgram_mss_updated(xqc_h3_conn_t *h, size_t mss, void *ud)
         if (udp_mss >= 68) {
             int new_mtu = (int)udp_mss;
             if (conn->addr6_assigned && new_mtu < IPV6_MIN_MTU) new_mtu = IPV6_MIN_MTU;
+            new_mtu = apply_mtu_cap(c->config.tun_mtu, new_mtu, c);
             if (new_mtu != c->last_notified_mtu) {
                 c->mtu = new_mtu;
                 c->last_notified_mtu = new_mtu;

--- a/src/mqvpn_config.c
+++ b/src/mqvpn_config.c
@@ -444,7 +444,7 @@ int
 mqvpn_config_set_tun_mtu(mqvpn_config_t *cfg, int mtu)
 {
     if (!cfg) return MQVPN_ERR_INVALID_ARG;
-    if (mtu != 0 && (mtu < 1280 || mtu > 65535)) return MQVPN_ERR_INVALID_ARG;
+    if (mtu != 0 && (mtu < 1280 || mtu > 9000)) return MQVPN_ERR_INVALID_ARG;
     cfg->tun_mtu = mtu;
     return MQVPN_OK;
 }

--- a/src/mqvpn_config.c
+++ b/src/mqvpn_config.c
@@ -439,3 +439,12 @@ mqvpn_config_set_max_clients(mqvpn_config_t *cfg, int max)
     cfg->max_clients = max;
     return MQVPN_OK;
 }
+
+int
+mqvpn_config_set_tun_mtu(mqvpn_config_t *cfg, int mtu)
+{
+    if (!cfg) return MQVPN_ERR_INVALID_ARG;
+    if (mtu != 0 && (mtu < 1280 || mtu > 65535)) return MQVPN_ERR_INVALID_ARG;
+    cfg->tun_mtu = mtu;
+    return MQVPN_OK;
+}

--- a/src/mqvpn_internal.h
+++ b/src/mqvpn_internal.h
@@ -47,6 +47,8 @@ struct mqvpn_config_s {
     /* draft-21 §4.6: initial Maximum Path Identifier we advertise in TP.
      * 0 = use xquic default (XQC_DEFAULT_INIT_MAX_PATH_ID = 8). */
     uint64_t init_max_path_id;
+
+    int tun_mtu; /* 0 = auto (negotiated), >0 = cap */
 };
 
 /* ─── State transition validation (M0-5) ─── */

--- a/src/mqvpn_server.c
+++ b/src/mqvpn_server.c
@@ -715,7 +715,21 @@ svr_masque_send_response(xqc_h3_request_t *h3_request, svr_stream_t *stream)
         client_info.assigned_prefix = 32;
         memcpy(client_info.server_ip, &s->pool.base.s_addr, 4);
         client_info.server_prefix = (uint8_t)s->pool.prefix_len;
-        client_info.mtu = 1280;
+        int client_mtu = IPV6_MIN_MTU;
+        if (conn->dgram_mss > 0) {
+            size_t udp_mss =
+                xqc_h3_ext_masque_udp_mss(conn->dgram_mss, conn->masque_stream_id);
+            if (udp_mss >= 68) client_mtu = (int)udp_mss;
+        }
+        if (s->config.tun_mtu > 0) {
+            if (s->config.tun_mtu < client_mtu) {
+                client_mtu = s->config.tun_mtu;
+            } else if (s->config.tun_mtu > client_mtu) {
+                LOG_W(s, "config MTU %d exceeds negotiated MTU %d, using %d",
+                      s->config.tun_mtu, client_mtu, client_mtu);
+            }
+        }
+        client_info.mtu = client_mtu;
         if (conn->has_v6) {
             memcpy(client_info.assigned_ip6, &conn->assigned_ip6, 16);
             client_info.assigned_prefix6 = (uint8_t)s->pool.prefix6;
@@ -1313,7 +1327,7 @@ mqvpn_server_start(mqvpn_server_t *s)
     info.assigned_prefix = (uint8_t)s->pool.prefix_len;
     memcpy(info.server_ip, &s->pool.base.s_addr, 4);
     info.server_prefix = (uint8_t)s->pool.prefix_len;
-    info.mtu = 1280;
+    info.mtu = s->config.tun_mtu > 0 ? s->config.tun_mtu : IPV6_MIN_MTU;
 
     if (s->pool.has_v6) {
         struct in6_addr srv_addr6;

--- a/src/platform/linux/platform_linux.c
+++ b/src/platform/linux/platform_linux.c
@@ -1016,6 +1016,7 @@ linux_platform_run_client(const mqvpn_client_cfg_t *cfg)
     }
     mqvpn_config_set_scheduler(lib_cfg, lib_sched);
     mqvpn_config_set_init_max_path_id(lib_cfg, cfg->init_max_path_id);
+    mqvpn_config_set_tun_mtu(lib_cfg, cfg->tun_mtu);
 
     /* Create callbacks */
     mqvpn_client_callbacks_t cbs = MQVPN_CLIENT_CALLBACKS_INIT;
@@ -1463,6 +1464,7 @@ linux_platform_run_server(const mqvpn_server_cfg_t *cfg)
     }
     mqvpn_config_set_scheduler(lib_cfg, lib_sched);
     mqvpn_config_set_init_max_path_id(lib_cfg, cfg->init_max_path_id);
+    mqvpn_config_set_tun_mtu(lib_cfg, cfg->tun_mtu);
 
     mqvpn_config_set_log_level(lib_cfg, (mqvpn_log_level_t)cfg->log_level);
 

--- a/src/platform/windows/platform_windows.c
+++ b/src/platform/windows/platform_windows.c
@@ -531,6 +531,7 @@ win_platform_run_client(const mqvpn_client_cfg_t *cfg)
     default: lib_sched = MQVPN_SCHED_MINRTT; break;
     }
     mqvpn_config_set_scheduler(lib_cfg, lib_sched);
+    mqvpn_config_set_tun_mtu(lib_cfg, cfg->tun_mtu);
 
     /* Create callbacks */
     mqvpn_client_callbacks_t cbs = MQVPN_CLIENT_CALLBACKS_INIT;

--- a/src/vpn_client.h
+++ b/src/vpn_client.h
@@ -21,6 +21,7 @@ typedef struct mqvpn_client_cfg_s {
     int reconnect_interval;     /* base reconnect interval in seconds (default 5) */
     int kill_switch;            /* 1=block traffic outside tunnel (default 0) */
     uint64_t init_max_path_id;  /* draft-21 §4.6 TP cap, 0=use xquic default 8 */
+    int tun_mtu;                /* 0=auto (MSS-derived), >0=cap (floor 1280) */
 } mqvpn_client_cfg_t;
 
 #endif /* MQVPN_VPN_CLIENT_H */

--- a/src/vpn_server.h
+++ b/src/vpn_server.h
@@ -27,6 +27,7 @@ typedef struct mqvpn_server_cfg_s {
     const char *control_addr;  /* bind address for JSON control API (default 127.0.0.1) */
     int control_port;          /* TCP port for JSON control API (0 = disabled) */
     uint64_t init_max_path_id; /* draft-21 §4.6 TP cap, 0=use xquic default 8 */
+    int tun_mtu;               /* 0=auto (1280 at startup), >0=override (floor 1280) */
 } mqvpn_server_cfg_t;
 
 #endif /* MQVPN_VPN_SERVER_H */

--- a/systemd/client.conf.example
+++ b/systemd/client.conf.example
@@ -13,6 +13,7 @@ Key = <YOUR_PSK_HERE>
 TunName = mqvpn0
 DNS = 1.1.1.1, 8.8.8.8
 LogLevel = info
+# MTU = 1280
 # KillSwitch = false
 # Reconnect = true
 # ReconnectInterval = 5

--- a/systemd/server.conf.example
+++ b/systemd/server.conf.example
@@ -7,6 +7,7 @@ Subnet = 10.0.0.0/24
 # Subnet6 = 2001:db8:1::/112
 TunName = mqvpn0
 LogLevel = info
+# MTU = 1280
 
 [TLS]
 Cert = /etc/mqvpn/server.crt

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -239,10 +239,10 @@ TEST(config_set_tun_mtu)
     ASSERT_EQ(cfg->tun_mtu, 1280);
     ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, 1350), MQVPN_OK);
     ASSERT_EQ(cfg->tun_mtu, 1350);
-    ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, 65535), MQVPN_OK);
-    ASSERT_EQ(cfg->tun_mtu, 65535);
+    ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, 9000), MQVPN_OK);
+    ASSERT_EQ(cfg->tun_mtu, 9000);
     ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, 1279), MQVPN_ERR_INVALID_ARG);
-    ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, 65536), MQVPN_ERR_INVALID_ARG);
+    ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, 9001), MQVPN_ERR_INVALID_ARG);
     ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, -1), MQVPN_ERR_INVALID_ARG);
     ASSERT_EQ(mqvpn_config_set_tun_mtu(NULL, 1400), MQVPN_ERR_INVALID_ARG);
     mqvpn_config_free(cfg);

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -230,6 +230,24 @@ TEST(config_set_insecure)
     mqvpn_config_free(cfg);
 }
 
+TEST(config_set_tun_mtu)
+{
+    mqvpn_config_t *cfg = mqvpn_config_new();
+    ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, 0), MQVPN_OK);
+    ASSERT_EQ(cfg->tun_mtu, 0);
+    ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, 1280), MQVPN_OK);
+    ASSERT_EQ(cfg->tun_mtu, 1280);
+    ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, 1350), MQVPN_OK);
+    ASSERT_EQ(cfg->tun_mtu, 1350);
+    ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, 65535), MQVPN_OK);
+    ASSERT_EQ(cfg->tun_mtu, 65535);
+    ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, 1279), MQVPN_ERR_INVALID_ARG);
+    ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, 65536), MQVPN_ERR_INVALID_ARG);
+    ASSERT_EQ(mqvpn_config_set_tun_mtu(cfg, -1), MQVPN_ERR_INVALID_ARG);
+    ASSERT_EQ(mqvpn_config_set_tun_mtu(NULL, 1400), MQVPN_ERR_INVALID_ARG);
+    mqvpn_config_free(cfg);
+}
+
 TEST(config_set_scheduler)
 {
     mqvpn_config_t *cfg = mqvpn_config_new();
@@ -1677,6 +1695,7 @@ main(void)
     run_config_load_json_duplicate_users_last_wins();
     run_config_load_json_invalid_users();
     run_config_set_insecure();
+    run_config_set_tun_mtu();
     run_config_set_scheduler();
     run_config_set_log_level();
     run_config_set_reconnect();

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -728,13 +728,13 @@ test_mtu_below_floor_ignored(void)
 static void
 test_mtu_above_ceiling_ignored(void)
 {
-    const char *ini = "[Interface]\nMTU = 70000\n";
+    const char *ini = "[Interface]\nMTU = 9001\n";
     char *path = write_tmp(ini);
     mqvpn_file_config_t cfg;
     mqvpn_config_defaults(&cfg);
     mqvpn_config_load(&cfg, path);
     unlink(path);
-    ASSERT_EQ_INT(cfg.tun_mtu, 0, "MTU > 65535 ignored → stays 0");
+    ASSERT_EQ_INT(cfg.tun_mtu, 0, "MTU > 9000 ignored → stays 0");
 }
 
 static void

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -690,6 +690,64 @@ test_reconnect_interval_invalid(void)
 }
 
 /* ================================================================
+ *  MTU config tests
+ * ================================================================ */
+
+static void
+test_mtu_default(void)
+{
+    mqvpn_file_config_t cfg;
+    mqvpn_config_defaults(&cfg);
+    ASSERT_EQ_INT(cfg.tun_mtu, 0, "default tun_mtu is 0 (auto)");
+}
+
+static void
+test_mtu_config_parse(void)
+{
+    const char *ini = "[Interface]\nMTU = 1350\n";
+    char *path = write_tmp(ini);
+    mqvpn_file_config_t cfg;
+    mqvpn_config_defaults(&cfg);
+    mqvpn_config_load(&cfg, path);
+    unlink(path);
+    ASSERT_EQ_INT(cfg.tun_mtu, 1350, "MTU 1350 parsed");
+}
+
+static void
+test_mtu_below_floor_ignored(void)
+{
+    const char *ini = "[Interface]\nMTU = 500\n";
+    char *path = write_tmp(ini);
+    mqvpn_file_config_t cfg;
+    mqvpn_config_defaults(&cfg);
+    mqvpn_config_load(&cfg, path);
+    unlink(path);
+    ASSERT_EQ_INT(cfg.tun_mtu, 0, "MTU < 1280 ignored → stays 0");
+}
+
+static void
+test_mtu_above_ceiling_ignored(void)
+{
+    const char *ini = "[Interface]\nMTU = 70000\n";
+    char *path = write_tmp(ini);
+    mqvpn_file_config_t cfg;
+    mqvpn_config_defaults(&cfg);
+    mqvpn_config_load(&cfg, path);
+    unlink(path);
+    ASSERT_EQ_INT(cfg.tun_mtu, 0, "MTU > 65535 ignored → stays 0");
+}
+
+static void
+test_mtu_json_parse(void)
+{
+    const char *json = "{\"mtu\": 1400}";
+    mqvpn_file_config_t cfg;
+    mqvpn_config_defaults(&cfg);
+    mqvpn_config_load_json_filecfg(&cfg, json);
+    ASSERT_EQ_INT(cfg.tun_mtu, 1400, "JSON MTU 1400 parsed");
+}
+
+/* ================================================================
  *  Subnet6 config tests
  * ================================================================ */
 
@@ -1237,6 +1295,13 @@ main(void)
     test_reconnect_config_parse();
     test_reconnect_config_true();
     test_reconnect_interval_invalid();
+
+    /* MTU tests */
+    test_mtu_default();
+    test_mtu_config_parse();
+    test_mtu_below_floor_ignored();
+    test_mtu_above_ceiling_ignored();
+    test_mtu_json_parse();
 
     /* subnet6 tests */
     test_subnet6_default();

--- a/tests/test_server.c
+++ b/tests/test_server.c
@@ -260,6 +260,28 @@ TEST(server_lifecycle)
     mqvpn_server_destroy(s);
 }
 
+TEST(server_lifecycle_with_tun_mtu)
+{
+    reset_mocks();
+    mqvpn_config_t *cfg = make_server_config();
+    mqvpn_config_set_tun_mtu(cfg, 1350);
+
+    mqvpn_server_callbacks_t cbs = MQVPN_SERVER_CALLBACKS_INIT;
+    cbs.tun_output = mock_tun_output;
+    cbs.tunnel_config_ready = mock_tunnel_config_ready;
+    cbs.log = mock_log;
+
+    mqvpn_server_t *s = mqvpn_server_new(cfg, &cbs, NULL);
+    ASSERT_NOT_NULL(s);
+    mqvpn_config_free(cfg);
+
+    ASSERT_EQ(mqvpn_server_start(s), MQVPN_OK);
+    ASSERT_EQ(g_last_tunnel_info.mtu, 1350);
+
+    mqvpn_server_stop(s);
+    mqvpn_server_destroy(s);
+}
+
 TEST(server_lifecycle_with_v6)
 {
     reset_mocks();
@@ -823,6 +845,7 @@ main(void)
 
     /* Lifecycle */
     run_server_lifecycle();
+    run_server_lifecycle_with_tun_mtu();
     run_server_lifecycle_with_v6();
     run_server_double_start();
 


### PR DESCRIPTION
#123 
support tun mtu configurable

## Summary

  - Add `[Interface] MTU` config (INI/JSON) to cap TUN MTU on client and server
  - Fix server-side hardcoded 1280: derive per-client MTU from DATAGRAM MSS
  - Valid range: 1280(ipv6 available min val)–9000(Jumbo frame), 0 = auto (current behavior)

## Details

  Client: `min(config MTU, MSS-derived MTU)`. Config unset uses MSS-derived (~1382).
  Server: config value at startup, or 1280 if unset. Per-client notification
  uses MSS-derived MTU when available (was hardcoded 1280).
  Config > negotiated MTU logs a warning and uses the negotiated value.
