### PR TITLE
ci: pin windows jobs to windows-2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,7 +539,10 @@ jobs:
         run: sudo scripts/ci_e2e/run_systemd_test.sh
 
   windows:
-    runs-on: windows-latest
+    # Pinned to windows-2022 (VS 2022). windows-latest migrated to VS 2026 in
+    # June 2026, where the hardcoded `-G "Visual Studio 17 2022"` generator finds
+    # no VS instance. Revisit (bump generator / Ninja) before windows-2022 retires.
+    runs-on: windows-2022
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,10 @@ jobs:
           # those. arm64 stays on 24.04 because GitHub has no 22.04 ARM runner.
           - { os: linux,   arch: amd64, runner: ubuntu-22.04     }
           - { os: linux,   arch: arm64, runner: ubuntu-24.04-arm }
-          - { os: windows, arch: amd64, runner: windows-latest   }
+          # amd64 pinned to windows-2022 (VS 2022): windows-latest migrated to
+          # VS 2026 in June 2026, breaking the hardcoded "Visual Studio 17 2022"
+          # generator. Revisit (bump generator / Ninja) before windows-2022 retires.
+          - { os: windows, arch: amd64, runner: windows-2022     }
           - { os: windows, arch: arm64, runner: windows-11-arm   }
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60


### PR DESCRIPTION
windows-latest migrated to Visual Studio 2026 (June 2026), where the hardcoded `-G "Visual Studio 17 2022"` generator finds no VS instance. Pin amd64 windows jobs to windows-2022 to keep the validated MSVC 2022 toolchain.