### PR TITLE
Fix/example subnet6

### DIFF
--- a/src/addr_pool.h
+++ b/src/addr_pool.h
@@ -30,7 +30,7 @@ typedef struct {
 /* Initialize pool from CIDR string (e.g. "10.0.0.0/24"). */
 int mqvpn_addr_pool_init(mqvpn_addr_pool_t *pool, const char *cidr);
 
-/* Initialize IPv6 pool from CIDR string (e.g. "2001:db8:1::/112").
+/* Initialize IPv6 pool from CIDR string (e.g. "fd00:abcd::/112").
  * Call after mqvpn_addr_pool_init(). Shares offsets with IPv4 pool. */
 int mqvpn_addr_pool_init6(mqvpn_addr_pool_t *pool, const char *cidr6);
 

--- a/src/config.h
+++ b/src/config.h
@@ -33,7 +33,7 @@ typedef struct mqvpn_file_config_s {
     /* [Interface] — server */
     char listen[280]; /* "bind:port" */
     char subnet[32];
-    char subnet6[64]; /* IPv6 tunnel subnet CIDR (e.g. "2001:db8:1::/112") */
+    char subnet6[64]; /* IPv6 tunnel subnet CIDR (e.g. "fd00:abcd::/112") */
 
     /* [Interface] — client */
     char dns_servers[MQVPN_CONFIG_MAX_DNS][64];

--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,7 @@ usage(const char *prog)
         "  --listen BIND:PORT        Listen address (server mode, default 0.0.0.0:443)\n"
         "  --subnet CIDR             Client IP pool (server mode, default 10.0.0.0/24)\n"
         "  --subnet6 CIDR            IPv6 client IP pool (server mode, e.g. "
-        "2001:db8:1::/112)\n"
+        "fd00:abcd::/112)\n"
         "  --tun-name NAME           TUN device name (default mqvpn0)\n"
         "  --cert PATH               TLS certificate (server mode)\n"
         "  --key PATH                TLS private key (server mode)\n"

--- a/systemd/server.conf.example
+++ b/systemd/server.conf.example
@@ -4,7 +4,7 @@
 [Interface]
 Listen = 0.0.0.0:443
 Subnet = 10.0.0.0/24
-# Subnet6 = 2001:db8:1::/112
+# Subnet6 = fd00:abcd::/112
 TunName = mqvpn0
 LogLevel = info
 # MTU = 1280                   # TUN MTU (1280–9000, default: auto = ~1382)

--- a/systemd/server.json.example
+++ b/systemd/server.json.example
@@ -2,7 +2,7 @@
   "mode": "server",
   "listen": "0.0.0.0:443",
   "subnet": "10.0.0.0/24",
-  "subnet6": "2001:db8:1::/112",
+  "subnet6": "fd00:abcd::/112",
   "tun_name": "mqvpn0",
   "log_level": "info",
   "cert_file": "/etc/mqvpn/server.crt",


### PR DESCRIPTION
2001:db8::/32 is a prefix reserved for documentation purposes under RFC 3849 and is not routed on actual networks.
revise it, since ULA is actually better for practical use.