### PR TITLE
fix(platform): re-arm tick timer after TUN-driven sends

### DIFF
--- a/src/platform/darwin/platform_darwin.c
+++ b/src/platform/darwin/platform_darwin.c
@@ -422,6 +422,15 @@ on_tun_read(evutil_socket_t fd, short what, void *arg)
             break;
         }
     }
+
+    /* The sends above updated the engine's requested wake (pacing flush,
+     * PTO) — drive the engine and re-arm the tick from it, exactly as
+     * on_socket_read does. Without this, outbound-only traffic leaves the
+     * old timer armed: if the sent packet is lost, no ACK arrives to
+     * re-arm, and the PTO probe waits on the stale (possibly seconds-out)
+     * timer. */
+    mqvpn_client_tick(p->client);
+    schedule_next_tick(p);
 }
 
 void

--- a/src/platform/linux/platform_linux.c
+++ b/src/platform/linux/platform_linux.c
@@ -388,6 +388,15 @@ on_tun_read(evutil_socket_t fd, short what, void *arg)
             break;
         }
     }
+
+    /* The sends above updated the engine's requested wake (pacing flush,
+     * PTO) — drive the engine and re-arm the tick from it, exactly as
+     * on_socket_read does. Without this, outbound-only traffic leaves the
+     * old timer armed: if the sent packet is lost, no ACK arrives to
+     * re-arm, and the PTO probe waits on the stale (possibly seconds-out)
+     * timer. */
+    mqvpn_client_tick(p->client);
+    schedule_next_tick(p);
 }
 
 void

--- a/src/platform/windows/platform_windows.c
+++ b/src/platform/windows/platform_windows.c
@@ -396,6 +396,15 @@ on_tun_read(evutil_socket_t fd, short what, void *arg)
             break;
         }
     }
+
+    /* The sends above updated the engine's requested wake (pacing flush,
+     * PTO) — drive the engine and re-arm the tick from it, exactly as
+     * on_socket_read does. Without this, outbound-only traffic leaves the
+     * old timer armed: if the sent packet is lost, no ACK arrives to
+     * re-arm, and the PTO probe waits on the stale (possibly seconds-out)
+     * timer. */
+    mqvpn_client_tick(p->client);
+    schedule_next_tick(p);
 }
 
 void


### PR DESCRIPTION
Sending TUN packets updates xquic's requested wake (pacing, PTO), but client on_tun_read never re-read it, leaving a stale timer armed. With outbound-only traffic and a lost packet, the PTO probe waited on that stale timer. Mirrors on_socket_read; the server TUN path already did this.