### PR TITLE
build: build BoringSSL with CMAKE_BUILD_TYPE=Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,15 +65,25 @@ jobs:
         uses: actions/cache@v6
         with:
           path: third_party/xquic/third_party/boringssl
-          key: bssl-${{ steps.bssl-pin.outputs.sha }}-linux-gcc-fpic-v1
+          key: bssl-${{ steps.bssl-pin.outputs.sha }}-linux-gcc-fpic-v2
 
       - name: Build BoringSSL
         if: steps.bssl-cache.outputs.cache-hit != 'true'
         run: |
           cd third_party/xquic/third_party/boringssl
           mkdir -p build && cd build
-          cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
+          # CMAKE_BUILD_TYPE is mandatory: BoringSSL sets no default, so
+          # omitting it builds at -O0 and enables BORINGSSL_DISPATCH_TEST
+          # instrumentation (~21% VPN throughput, ~7x on X25519). The cache
+          # key is bumped with it — the cached path holds the build dir.
+          cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
           make -j$(nproc) ssl crypto
+
+      # Deliberately not gated on the cache miss: a cache restored from before
+      # the CMAKE_BUILD_TYPE fix is exactly what this is meant to catch.
+      - name: Verify BoringSSL is an optimized build
+        run: bash scripts/ci_check_bssl_optimized.sh third_party/xquic/third_party/boringssl/build
 
       - name: Cache xquic (Release)
         id: xquic-cache
@@ -88,7 +98,10 @@ jobs:
           path: |
             third_party/xquic/build
             third_party/xquic/include/xquic/xqc_configure.h
-          key: xquic-${{ steps.xqsha.outputs.sha }}-linux-gcc-release-bssl-${{ steps.bssl-pin.outputs.sha }}-v4
+          # v5: libxquic.so statically absorbs BoringSSL (hidden-visibility
+          # symbols), so a cached xquic build outlives a BoringSSL flag change
+          # unless this key moves with it.
+          key: xquic-${{ steps.xqsha.outputs.sha }}-linux-gcc-release-bssl-${{ steps.bssl-pin.outputs.sha }}-v5
 
       - name: Build xquic
         if: steps.xquic-cache.outputs.cache-hit != 'true'
@@ -162,6 +175,9 @@ jobs:
         run: |
           cd third_party/xquic/third_party/boringssl
           mkdir -p build && cd build
+          # No CMAKE_BUILD_TYPE here on purpose — the clang Debug arms want
+          # BoringSSL unoptimized with its asserts live. Release belongs on the
+          # shipping builds only (see the `build` job).
           CC=clang CXX=clang++ cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
           make -j$(nproc) ssl crypto
 
@@ -410,6 +426,7 @@ jobs:
         run: |
           cd third_party/xquic/third_party/boringssl
           mkdir -p build && cd build
+          # No CMAKE_BUILD_TYPE here on purpose — see the sanitizer job.
           CC=clang CXX=clang++ cmake \
             -DBUILD_SHARED_LIBS=0 \
             -DBUILD_TESTING=OFF \
@@ -597,14 +614,15 @@ jobs:
         uses: actions/cache@v6
         with:
           path: third_party/xquic/third_party/boringssl
-          key: bssl-${{ steps.bssl-pin.outputs.sha }}-darwin-arm64-clang-v1
+          key: bssl-${{ steps.bssl-pin.outputs.sha }}-darwin-arm64-clang-v2
 
       - name: Build BoringSSL
         if: steps.bssl-cache.outputs.cache-hit != 'true'
         run: |
           cd third_party/xquic/third_party/boringssl
           mkdir -p build && cd build
-          cmake -DBUILD_SHARED_LIBS=0 ..
+          # See the linux-build job re: why CMAKE_BUILD_TYPE is mandatory.
+          cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_BUILD_TYPE=Release ..
           make -j"$(sysctl -n hw.ncpu)" ssl crypto
 
       - name: Cache xquic (darwin Release)
@@ -615,7 +633,8 @@ jobs:
           path: |
             third_party/xquic/build
             third_party/xquic/include/xquic/xqc_configure.h
-          key: xquic-${{ steps.xqsha.outputs.sha }}-darwin-arm64-clang-release-bssl-${{ steps.bssl-pin.outputs.sha }}-v1
+          # v2: bumped with the BoringSSL cache — see the linux-build job.
+          key: xquic-${{ steps.xqsha.outputs.sha }}-darwin-arm64-clang-release-bssl-${{ steps.bssl-pin.outputs.sha }}-v2
 
       - name: Build xquic
         if: steps.xquic-cache.outputs.cache-hit != 'true'
@@ -1019,6 +1038,9 @@ jobs:
         run: |
           cd third_party/xquic/third_party/boringssl
           mkdir -p build && cd build
+          # No CMAKE_BUILD_TYPE here on purpose — the clang Debug arms want
+          # BoringSSL unoptimized with its asserts live. Release belongs on the
+          # shipping builds only (see the `build` job).
           CC=clang CXX=clang++ cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
           make -j$(nproc) ssl crypto
 
@@ -1116,6 +1138,9 @@ jobs:
         run: |
           cd third_party/xquic/third_party/boringssl
           mkdir -p build && cd build
+          # No CMAKE_BUILD_TYPE here on purpose — the clang Debug arms want
+          # BoringSSL unoptimized with its asserts live. Release belongs on the
+          # shipping builds only (see the `build` job).
           CC=clang CXX=clang++ cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
           make -j$(nproc) ssl crypto
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,14 +44,18 @@ jobs:
         uses: actions/cache@v6
         with:
           path: third_party/xquic/third_party/boringssl
-          key: bssl-${{ steps.bssl-pin.outputs.sha }}-linux-gcc-fpic-v1
+          key: bssl-${{ steps.bssl-pin.outputs.sha }}-linux-gcc-fpic-v2
 
       - name: Build BoringSSL
         if: steps.bssl-cache.outputs.cache-hit != 'true'
         run: |
           cd third_party/xquic/third_party/boringssl
           mkdir -p build && cd build
-          cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
+          # Must stay byte-identical to ci.yml's linux-build step: both jobs
+          # share the bssl-*-linux-gcc-fpic-* cache key. See there re: why
+          # CMAKE_BUILD_TYPE is mandatory.
+          cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
           make -j$(nproc) ssl crypto
 
       - name: Initialize CodeQL
@@ -72,7 +76,8 @@ jobs:
           path: |
             third_party/xquic/build
             third_party/xquic/include/xquic/xqc_configure.h
-          key: xquic-${{ steps.xqsha.outputs.sha }}-linux-gcc-release-bssl-${{ steps.bssl-pin.outputs.sha }}-v3
+          # v4: bumped with the BoringSSL cache — libxquic.so absorbs it.
+          key: xquic-${{ steps.xqsha.outputs.sha }}-linux-gcc-release-bssl-${{ steps.bssl-pin.outputs.sha }}-v4
 
       - name: Build xquic (CodeQL traced)
         if: steps.xquic-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/perf-weekly.yml
+++ b/.github/workflows/perf-weekly.yml
@@ -44,7 +44,10 @@ jobs:
         run: |
           cd third_party/xquic/third_party/boringssl
           mkdir -p build && cd build
-          cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
+          # See perf.yml re: why CMAKE_BUILD_TYPE is mandatory — results from
+          # before this line were taken against an -O0 crypto library.
+          cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
           make -j$(nproc) ssl crypto
 
       - name: Build xquic

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -46,8 +46,16 @@ jobs:
         run: |
           cd third_party/xquic/third_party/boringssl
           mkdir -p build && cd build
-          cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
+          # CMAKE_BUILD_TYPE is mandatory: BoringSSL sets no default, so
+          # omitting it benchmarks an -O0 crypto library. Measured on the
+          # netns harness: ~21% lower VPN throughput across single-path,
+          # MinRTT and WLB. Results from before this line are not comparable.
+          cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
           make -j$(nproc) ssl crypto
+
+      - name: Verify BoringSSL is an optimized build
+        run: bash scripts/ci_check_bssl_optimized.sh third_party/xquic/third_party/boringssl/build
 
       - name: Build xquic
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,8 +94,16 @@ jobs:
         run: |
           cd third_party/xquic/third_party/boringssl
           mkdir -p build && cd build
-          cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
+          # CMAKE_BUILD_TYPE is mandatory: BoringSSL sets no default, so
+          # omitting it ships an -O0 library with BORINGSSL_DISPATCH_TEST
+          # instrumentation (~21% VPN throughput, ~7x on X25519).
+          cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
           make -j$(nproc) ssl crypto
+
+      - name: Verify BoringSSL is an optimized build (Linux)
+        if: matrix.os == 'linux'
+        run: bash scripts/ci_check_bssl_optimized.sh third_party/xquic/third_party/boringssl/build
 
       - name: Build xquic
         if: matrix.os == 'linux'
@@ -206,8 +214,13 @@ jobs:
         run: |
           cd third_party/xquic/third_party/boringssl
           mkdir -p build && cd build
-          cmake -DBUILD_SHARED_LIBS=0 ..
+          # See the Linux BoringSSL step re: why CMAKE_BUILD_TYPE is mandatory.
+          cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_BUILD_TYPE=Release ..
           make -j"$(sysctl -n hw.ncpu)" ssl crypto
+
+      - name: Verify BoringSSL is an optimized build (macOS)
+        if: matrix.os == 'darwin'
+        run: bash scripts/ci_check_bssl_optimized.sh third_party/xquic/third_party/boringssl/build
 
       - name: Build xquic (macOS)
         if: matrix.os == 'darwin'

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           cd third_party/xquic/third_party/boringssl
           mkdir -p build && cd build
+          # No CMAKE_BUILD_TYPE here on purpose — see ci.yml's sanitizer job.
           CC=clang CXX=clang++ cmake -DBUILD_SHARED_LIBS=0 -DBUILD_TESTING=OFF \
             -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
           make -j$(nproc) ssl crypto

--- a/README.md
+++ b/README.md
@@ -538,9 +538,12 @@ cd mqvpn
 
 ```bash
 # 1. Build BoringSSL
+# CMAKE_BUILD_TYPE is required — BoringSSL has no default build type, and
+# omitting it produces an unoptimized library (~21% less VPN throughput).
 cd third_party/xquic/third_party/boringssl
 mkdir -p build && cd build
-cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
+cmake -DBUILD_SHARED_LIBS=0 -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" ..
 make -j$(nproc) ssl crypto
 cd ../../../../..
 

--- a/build.sh
+++ b/build.sh
@@ -63,9 +63,28 @@ echo "=== Building BoringSSL ==="
 source "$SCRIPT_DIR/scripts/bssl_build_guard.sh"
 bssl_guard_build_dir "$BSSL_DIR" "$BSSL_BUILD"
 mkdir -p "$BSSL_BUILD"
+# CMAKE_BUILD_TYPE is mandatory: BoringSSL's CMakeLists sets no default, so
+# omitting it compiles the whole library at -O0 with asserts live, and its
+# `NOT CMAKE_BUILD_TYPE MATCHES "rel"` guard additionally defines
+# BORINGSSL_DISPATCH_TEST (CPU-dispatch test instrumentation). Measured cost
+# of the omission: ~21% VPN throughput and ~7x on X25519.
 if [ ! -f "$BSSL_BUILD/CMakeCache.txt" ]; then
     cmake -S "$BSSL_DIR" -B "$BSSL_BUILD" \
         -DBUILD_SHARED_LIBS=0 \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_FLAGS="-fPIC" \
+        -DCMAKE_CXX_FLAGS="-fPIC"
+elif ! grep -qiE '^CMAKE_BUILD_TYPE:STRING=Rel' "$BSSL_BUILD/CMakeCache.txt"; then
+    # A build dir configured before that flag existed would silently keep its
+    # -O0 objects, since the configure above is skipped once a cache exists.
+    # Any Rel* type is left alone — that is the same prefix BoringSSL's own
+    # CMakeLists tests to decide whether the build is an optimized one.
+    echo "BoringSSL build dir was configured without CMAKE_BUILD_TYPE=Release — reconfiguring"
+    rm -rf "$BSSL_BUILD"
+    mkdir -p "$BSSL_BUILD"
+    cmake -S "$BSSL_DIR" -B "$BSSL_BUILD" \
+        -DBUILD_SHARED_LIBS=0 \
+        -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_C_FLAGS="-fPIC" \
         -DCMAKE_CXX_FLAGS="-fPIC"
 fi

--- a/scripts/ci_check_bssl_optimized.sh
+++ b/scripts/ci_check_bssl_optimized.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 mp0rta and mqvpn contributors
+#
+# Fail if BoringSSL was built without CMAKE_BUILD_TYPE=Release.
+#
+# BoringSSL's CMakeLists sets no default build type. With CMAKE_BUILD_TYPE
+# empty, CMAKE_C_FLAGS_RELEASE never applies (so the library compiles at -O0
+# with asserts live) and its `NOT CMAKE_BUILD_TYPE MATCHES "rel"` guard
+# additionally defines BORINGSSL_DISPATCH_TEST, which instruments the AES/GCM
+# dispatch entry points. Measured cost on the netns harness: ~21% VPN
+# throughput, and ~7x on X25519 (pure C, no asm path).
+#
+# Both failure modes leave the same fingerprint: BORINGSSL_function_hit, the
+# dispatch-test flag array, exists only in a non-"rel" build. Checking for it
+# in the built archive catches the mistake wherever it comes from — a missing
+# flag, or a stale cache restored from before the flag was added.
+#
+# Usage: ci_check_bssl_optimized.sh <boringssl-build-dir>
+set -euo pipefail
+
+BUILD_DIR="${1:?usage: ci_check_bssl_optimized.sh <boringssl-build-dir>}"
+
+# Newer BoringSSL layouts place the archives at the build root; older ones use
+# crypto/ + ssl/ subdirs (same probe order as CMakeLists.txt and build.sh).
+if [ -f "$BUILD_DIR/crypto/libcrypto.a" ]; then
+    ARCHIVE="$BUILD_DIR/crypto/libcrypto.a"
+elif [ -f "$BUILD_DIR/libcrypto.a" ]; then
+    ARCHIVE="$BUILD_DIR/libcrypto.a"
+else
+    echo "ERROR: libcrypto.a not found under $BUILD_DIR" >&2
+    exit 1
+fi
+
+SYMS="$(mktemp)"
+trap 'rm -f "$SYMS"' EXIT
+
+# No `nm ... | grep -q`: grep would exit at the first match and leave nm
+# writing into a closed pipe (SIGPIPE), which under `set -o pipefail` turns a
+# successful check into a spurious failure.
+nm "$ARCHIVE" > "$SYMS" 2>/dev/null || true
+
+# An empty or unreadable symbol table would make the grep below pass
+# vacuously — the exact way a canary check rots into a no-op.
+if [ "$(wc -l < "$SYMS")" -lt 100 ]; then
+    echo "ERROR: could not read symbols from $ARCHIVE — check cannot run" >&2
+    exit 1
+fi
+
+if grep -q "BORINGSSL_function_hit" "$SYMS"; then
+    echo "ERROR: $ARCHIVE was built without CMAKE_BUILD_TYPE=Release." >&2
+    echo "       BORINGSSL_DISPATCH_TEST instrumentation is compiled in, which" >&2
+    echo "       means the library is also unoptimized (-O0)." >&2
+    echo "       Fix: pass -DCMAKE_BUILD_TYPE=Release to BoringSSL's cmake, and" >&2
+    echo "       bump the BoringSSL/xquic cache keys if a CI cache is involved." >&2
+    exit 1
+fi
+
+echo "OK: $ARCHIVE is an optimized BoringSSL build"


### PR DESCRIPTION
BoringSSL sets no default build type, so every configure that omitted it produced an -O0 library with asserts live and BORINGSSL_DISPATCH_TEST instrumentation compiled in — shipped in the Linux and macOS release artifacts, and benchmarked by perf.yml.

Netns A/B with only libcrypto.a swapped: +21% VPN throughput on single-path, MinRTT and WLB alike, and 7.2x on X25519. The BoringSSL and xquic cache keys move together because libxquic.so absorbs BoringSSL's objects. The clang Debug sanitizer arms keep their unoptimized build on purpose.